### PR TITLE
dynamic status filter

### DIFF
--- a/packages/app/components/Proposals/ProposalGrid.tsx
+++ b/packages/app/components/Proposals/ProposalGrid.tsx
@@ -52,6 +52,7 @@ const ProposalGrid: React.FC<ProposalGridProps> = ({ proposalType }) => {
         .then((res) => setProposals(res));
     }
   }, [contracts]);
+
   return (
     <div className="w-full bg-gray-900 pb-16">
       <Navbar />
@@ -135,13 +136,15 @@ const ProposalGrid: React.FC<ProposalGridProps> = ({ proposalType }) => {
                   setStatusFilter(ProposalStatus[status]);
                 }}
               >
-                {new Array(6).fill(undefined).map((x, status) => {
-                  return (
-                    <option value={ProposalStatus[status]}>
-                      {ProposalStatus[status]}
-                    </option>
-                  );
-                })}
+                {Object.keys(ProposalStatus)
+                  .slice(0, Object.keys(ProposalStatus).length / 2)
+                  .map((status) => {
+                    return (
+                      <option value={ProposalStatus[status]}>
+                        {ProposalStatus[status]}
+                      </option>
+                    );
+                  })}
               </select>
               <div className="pointer-events-none absolute inset-y-0 right-0 px-2 flex items-center">
                 <ChevronDownIcon


### PR DESCRIPTION
The status filter is now dynamic and not taking a fixed size array anymore.


Apparently an enum is an Object in which double the amounts of keys than items exist. 

For example:
{"0":"Status1",
"1": "Status2",
Status1:"0",
Status2:"1"}

Therefore the Object.keys(items) array must be sliced to only take the first half of keys.