### PR TITLE
Added keeper burn

### DIFF
--- a/packages/contracts/contracts/KeeperIncentive.sol
+++ b/packages/contracts/contracts/KeeperIncentive.sol
@@ -1,12 +1,11 @@
 pragma solidity >=0.7.0 <0.8.0;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
-import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "./Governed.sol";
 
 contract KeeperIncentive is Governed {
   using SafeMath for uint256;
-  using SafeERC20 for IERC20;
 
   struct Incentive {
     uint256 reward; //pop reward for calling the function
@@ -16,9 +15,12 @@ contract KeeperIncentive is Governed {
 
   /* ========== STATE VARIABLES ========== */
 
-  IERC20 public immutable POP;
+  ERC20 public immutable POP;
   Incentive[] public incentives;
   uint256 public incentiveBudget;
+  uint256 public burnRate;
+  address internal immutable burnAddress =
+    0x00000000219ab540356cBB839Cbe05303d7705Fa; //ETH2.0 Staking Contract
   mapping(address => bool) public approved;
 
   /* ========== EVENTS ========== */
@@ -30,11 +32,15 @@ contract KeeperIncentive is Governed {
   event RemovedApproval(address account);
   event ApprovalToggled(uint256 incentiveId, bool openToEveryone);
   event IncentiveToggled(uint256 incentiveId, bool enabled);
+  event BurnFundet(uint256 amount);
+  event Burned(uint256 amount);
+  event BurnRateChanged(uint256 oldRate, uint256 newRate);
 
   /* ========== CONSTRUCTOR ========== */
 
-  constructor(address _governance, IERC20 _pop) public Governed(_governance) {
+  constructor(address _governance, ERC20 _pop) public Governed(_governance) {
     POP = _pop;
+    burnRate = 25e16; // 25% of intentive.reward
     createIncentive(10e18, true, false);
   }
 
@@ -63,6 +69,15 @@ contract KeeperIncentive is Governed {
     );
     emit IncentiveCreated(incentives.length);
     return incentives.length;
+  }
+
+  /**
+   * @notice Sets the current burn rate as a percentage of the incentive reward.
+   * @param _burnRate Percentage in Mantissa. (1e14 = 1 Basis Point)
+   */
+  function setBurnRate(uint256 _burnRate) external onlyGovernance {
+    emit BurnRateChanged(burnRate, _burnRate);
+    burnRate = _burnRate;
   }
 
   /* ========== RESTRICTED FUNCTIONS ========== */
@@ -103,9 +118,14 @@ contract KeeperIncentive is Governed {
   }
 
   function fundIncentive(uint256 _amount) external {
-    POP.safeTransferFrom(msg.sender, address(this), _amount);
+    POP.transferFrom(msg.sender, address(this), _amount);
     incentiveBudget = incentiveBudget.add(_amount);
     emit IncentiveFunded(_amount);
+  }
+
+  function _burn(uint256 _amount) internal {
+    POP.transfer(burnAddress, _amount);
+    emit Burned(_amount);
   }
 
   /* ========== MODIFIER ========== */
@@ -122,8 +142,11 @@ contract KeeperIncentive is Governed {
       }
       if (incentive.reward <= incentiveBudget) {
         incentiveBudget = incentiveBudget.sub(incentive.reward);
-        POP.approve(address(this), incentive.reward);
-        POP.safeTransferFrom(address(this), msg.sender, incentive.reward);
+        uint256 amountToBurn = incentive.reward.mul(burnRate).div(1e18);
+        uint256 incentivePayout = incentive.reward.sub(amountToBurn);
+        POP.approve(address(this), incentivePayout);
+        POP.transferFrom(address(this), msg.sender, incentivePayout);
+        _burn(amountToBurn);
       }
     }
     _;

--- a/packages/contracts/contracts/RewardsManager.sol
+++ b/packages/contracts/contracts/RewardsManager.sol
@@ -67,7 +67,7 @@ contract RewardsManager is
   /* ========== CONSTRUCTOR ========== */
 
   constructor(
-    IERC20 pop_,
+    ERC20 pop_,
     IStaking staking_,
     ITreasury treasury_,
     IInsurance insurance_,
@@ -143,17 +143,17 @@ contract RewardsManager is
 
     //@todo check edge case precision overflow
     uint256 _stakingAmount = _availableReward
-    .mul(rewardSplits[uint8(RewardTargets.Staking)])
-    .div(100e18);
+      .mul(rewardSplits[uint8(RewardTargets.Staking)])
+      .div(100e18);
     uint256 _treasuryAmount = _availableReward
-    .mul(rewardSplits[uint8(RewardTargets.Treasury)])
-    .div(100e18);
+      .mul(rewardSplits[uint8(RewardTargets.Treasury)])
+      .div(100e18);
     uint256 _insuranceAmount = _availableReward
-    .mul(rewardSplits[uint8(RewardTargets.Insurance)])
-    .div(100e18);
+      .mul(rewardSplits[uint8(RewardTargets.Insurance)])
+      .div(100e18);
     uint256 _beneficiaryVaultsAmount = _availableReward
-    .mul(rewardSplits[uint8(RewardTargets.BeneficiaryVaults)])
-    .div(100e18);
+      .mul(rewardSplits[uint8(RewardTargets.BeneficiaryVaults)])
+      .div(100e18);
 
     _distributeToStaking(_stakingAmount);
     _distributeToTreasury(_treasuryAmount);

--- a/packages/contracts/contracts/test_helpers/KeeperIncentiveHelper.sol
+++ b/packages/contracts/contracts/test_helpers/KeeperIncentiveHelper.sol
@@ -1,18 +1,17 @@
 pragma solidity >=0.6.0 <0.8.0;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 
 import "../KeeperIncentive.sol";
 
 contract KeeperIncentiveHelper is KeeperIncentive {
-  using SafeERC20 for IERC20;
   using SafeMath for uint256;
 
   event FunctionCalled(address account);
 
-  constructor(IERC20 pop_) public KeeperIncentive(msg.sender, pop_) {}
+  constructor(ERC20 pop_) public KeeperIncentive(msg.sender, pop_) {}
 
   function defaultIncentivisedFunction() public keeperIncentive(0) {
     emit FunctionCalled(msg.sender);

--- a/packages/contracts/test/KeeperIncentive.test.ts
+++ b/packages/contracts/test/KeeperIncentive.test.ts
@@ -76,6 +76,21 @@ describe("Keeper incentives", function () {
     ).to.be.revertedWith(
       "Only the contract governance may perform this action"
     );
+    await expect(
+      keeperIncentiveHelper.connect(nonOwner).setBurnRate(0)
+    ).to.be.revertedWith(
+      "Only the contract governance may perform this action"
+    );
+  });
+  it("should adjust the burn rate", async function () {
+    expect(
+      await keeperIncentiveHelper.connect(owner).setBurnRate(parseEther("0.1"))
+    )
+      .to.emit(keeperIncentiveHelper, "BurnRateChanged")
+      .withArgs(parseEther("0.25"), parseEther("0.1"));
+    expect(await keeperIncentiveHelper.burnRate()).to.be.equal(
+      parseEther("0.1")
+    );
   });
   describe("change incentives", function () {
     it("should change the whole incentive", async function () {
@@ -194,7 +209,7 @@ describe("Keeper incentives", function () {
         .to.emit(keeperIncentiveHelper, "FunctionCalled")
         .withArgs(owner.address);
       const newBalance = await mockPop.balanceOf(owner.address);
-      expect(newBalance).to.deep.equal(oldBalance.add(incentive));
+      expect(newBalance).to.deep.equal(oldBalance.add(incentive.mul(3).div(4)));
     });
     it("should not pay out rewards if the incentive budget is not high enough", async function () {
       const oldBalance = await mockPop.balanceOf(owner.address);
@@ -228,7 +243,7 @@ describe("Keeper incentives", function () {
           .to.emit(keeperIncentiveHelper, "FunctionCalled")
           .withArgs(nonOwner.address);
         const newbalance = await mockPop.balanceOf(nonOwner.address);
-        expect(newbalance).to.equal(oldBalance.add(incentive));
+        expect(newbalance).to.equal(oldBalance.add(incentive.mul(3).div(4)));
       });
     });
     context("should not do anything ", function () {


### PR DESCRIPTION
Keeper functions now "burn" a portion of the incentives everytime a keeper calls an incentivized function.
We send the POP to the beaconChain staking address where they shouldnt be accessible anymore.