### PR TITLE
Increase management fee period

### DIFF
--- a/packages/contracts/contracts/pool/Pool.sol
+++ b/packages/contracts/contracts/pool/Pool.sol
@@ -213,10 +213,10 @@ contract Pool is AffiliateToken, Ownable, ReentrancyGuard, Pausable, Defended {
     if (pricePerPoolToken() > poolTokenHWM) {
       uint256 changeInPricePerToken = pricePerPoolToken().sub(poolTokenHWM);
       uint256 fee = performanceFee
-      .mul(changeInPricePerToken)
-      .mul(totalSupply())
-      .div(BPS_DENOMINATOR)
-      .div(1e18);
+        .mul(changeInPricePerToken)
+        .mul(totalSupply())
+        .div(BPS_DENOMINATOR)
+        .div(1e18);
       _issuePoolTokensForAmount(address(this), fee);
       emit PerformanceFee(fee);
     }

--- a/packages/contracts/contracts/pool/Pool.sol
+++ b/packages/contracts/contracts/pool/Pool.sol
@@ -20,7 +20,7 @@ contract Pool is AffiliateToken, Ownable, ReentrancyGuard, Pausable, Defended {
   address public rewardsManager;
 
   uint256 constant BPS_DENOMINATOR = 10_000;
-  uint256 constant SECONDS_PER_YEAR = 31_556_952;
+  uint256 constant MINUTES_PER_YEAR = 525_600;
 
   uint256 public withdrawalFee = 50;
   uint256 public managementFee = 200;
@@ -199,9 +199,9 @@ contract Pool is AffiliateToken, Ownable, ReentrancyGuard, Pausable, Defended {
   }
 
   function _takeManagementFee() internal {
-    uint256 period = block.timestamp.sub(feesUpdatedAt);
+    uint256 period = block.timestamp.sub(feesUpdatedAt).div(1 minutes);
     uint256 fee = (managementFee.mul(totalValue()).mul(period)).div(
-      SECONDS_PER_YEAR.mul(BPS_DENOMINATOR)
+      MINUTES_PER_YEAR.mul(BPS_DENOMINATOR)
     );
     if (fee > 0) {
       _issuePoolTokensForAmount(address(this), fee);
@@ -213,10 +213,10 @@ contract Pool is AffiliateToken, Ownable, ReentrancyGuard, Pausable, Defended {
     if (pricePerPoolToken() > poolTokenHWM) {
       uint256 changeInPricePerToken = pricePerPoolToken().sub(poolTokenHWM);
       uint256 fee = performanceFee
-        .mul(changeInPricePerToken)
-        .mul(totalSupply())
-        .div(BPS_DENOMINATOR)
-        .div(1e18);
+      .mul(changeInPricePerToken)
+      .mul(totalSupply())
+      .div(BPS_DENOMINATOR)
+      .div(1e18);
       _issuePoolTokensForAmount(address(this), fee);
       emit PerformanceFee(fee);
     }

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -235,6 +235,7 @@ module.exports = {
       accounts: [process.env.PRIVATE_KEY],
     },
     hardhat: {
+      initialBaseFeePerGas: 0,
       forking:
         process.env.FORKING_ENABLED == "true"
           ? {

--- a/packages/contracts/test/Pool.test.ts
+++ b/packages/contracts/test/Pool.test.ts
@@ -879,7 +879,7 @@ describe("Pool", function () {
       });
     });
 
-    xdescribe("combined fees", async function () {
+    describe("combined fees", async function () {
       it("combined fees over time", async function () {
         let initialDeposit = parseEther("10000");
         await contracts.mockToken
@@ -927,7 +927,7 @@ describe("Pool", function () {
         expect(await contracts.pool.totalValue()).to.equal(parseEther("11000"));
 
         // We've had assets worth $11,000 under management for 30 days.
-        // Management fee:  $18.07
+        // Management fee:  $18.08
 
         // We've earned $1000 profit this period
         // Performance fee: $196
@@ -939,34 +939,34 @@ describe("Pool", function () {
           .withArgs(
             depositor2.address,
             parseEther("10000"),
-            parseEther("9271.669698336058197924")
+            parseEther("9271.677945091345085999")
           )
           .and.emit(contracts.pool, "ManagementFee")
-          .withArgs(parseEther("18.070200189169093390"))
+          .withArgs(parseEther("18.082191780821917808"))
           .and.emit(contracts.pool, "PerformanceFee")
-          .withArgs(parseEther("196.709102950288323885"));
+          .withArgs(parseEther("196.706915477497255323"));
 
         // yVault share price: $1.10
         // Pool token price:   $1.07
         // Total pool value: $20,999
         // Pool share value: $214
         expect(await contracts.pool.pricePerPoolToken()).to.equal(
-          parseEther("1.078554383984866471")
+          parseEther("1.078553424657534245")
         );
         expect(await contracts.pool.totalValue()).to.equal(
           parseEther("20999.999999999999991427")
         );
         expect(await contracts.pool.balanceOf(contracts.pool.address)).to.equal(
-          parseEther("198.836668169664009768")
+          parseEther("198.845739600479586651")
         );
         expect(await contracts.pool.totalSupply()).to.equal(
-          parseEther("19470.506366505722207692")
+          parseEther("19470.523684691824672650")
         );
         expect(
           await contracts.pool.valueFor(
             await contracts.pool.balanceOf(contracts.pool.address)
           )
-        ).to.equal(parseEther("214.456160151335273221"));
+        ).to.equal(parseEther("214.465753424657533639"));
 
         let yearnPrice = await contracts.mockYearnVault.pricePerShare();
         await contracts.mockYearnVault.setPricePerFullShare(
@@ -989,34 +989,34 @@ describe("Pool", function () {
           .withArgs(
             depositor3.address,
             parseEther("10000"),
-            parseEther("8596.385899504305242976")
+            parseEther("8596.401191749326745270")
           )
           .and.emit(contracts.pool, "ManagementFee")
-          .withArgs(parseEther("37.947420397255096074"))
+          .withArgs(parseEther("37.972602739726027352"))
           .and.emit(contracts.pool, "PerformanceFee")
-          .withArgs(parseEther("413.089116195605481713"));
+          .withArgs(parseEther("413.084522502744233634"));
 
         // yVault share price: $1.21
         // Pool token price:   $1.16
         // Total pool value: $33,099
         // Pool share value: $681
         expect(await contracts.pool.pricePerPoolToken()).to.equal(
-          parseEther("1.163279559212974789")
+          parseEther("1.163277489840495400")
         );
         expect(await contracts.pool.totalValue()).to.equal(
           parseEther("33099.999999999999973372")
         );
         expect(await contracts.pool.balanceOf(contracts.pool.address)).to.equal(
-          parseEther("585.981729518886890461")
+          parseEther("586.008807849599672685")
         );
         expect(await contracts.pool.totalSupply()).to.equal(
-          parseEther("28454.037327359250331361")
+          parseEther("28454.087944690271503954")
         );
         expect(
           await contracts.pool.valueFor(
             await contracts.pool.balanceOf(contracts.pool.address)
           )
-        ).to.equal(parseEther("681.660568021587359665"));
+        ).to.equal(parseEther("681.690855019703504805"));
 
         yearnPrice = await contracts.mockYearnVault.pricePerShare();
         await contracts.mockYearnVault.setPricePerFullShare(
@@ -1039,41 +1039,41 @@ describe("Pool", function () {
           .withArgs(
             depositor4.address,
             parseEther("10000"),
-            parseEther("7970.285065963742610210")
+            parseEther("7970.306333669918777123")
           )
           .and.emit(contracts.pool, "ManagementFee")
-          .withArgs(parseEther("59.812362626149699023"))
+          .withArgs(parseEther("59.852054794520547846"))
           .and.emit(contracts.pool, "PerformanceFee")
-          .withArgs(parseEther("651.107130765454348514"));
+          .withArgs(parseEther("651.099890230515914336"));
 
         // yVault share price: $1.33
         // Pool token price:   $1.25
         // Total pool value: $46,409
         // Pool share value: $1,445
         expect(await contracts.pool.pricePerPoolToken()).to.equal(
-          parseEther("1.254660268389137024")
+          parseEther("1.254656920494486315")
         );
         expect(await contracts.pool.totalValue()).to.equal(
           parseEther("46409.999999999999936980")
         );
         expect(await contracts.pool.balanceOf(contracts.pool.address)).to.equal(
-          parseEther("1151.752327333623352649")
+          parseEther("1151.806224051502386010")
         );
         expect(await contracts.pool.totalSupply()).to.equal(
-          parseEther("36990.092991137729403759")
+          parseEther("36990.191694562092994402")
         );
         expect(
           await contracts.pool.valueFor(
             await contracts.pool.balanceOf(contracts.pool.address)
           )
-        ).to.equal(parseEther("1445.057884130217075157"));
+        ).to.equal(parseEther("1445.121650074840320630"));
 
         yearnPrice = await contracts.mockYearnVault.pricePerShare();
         await contracts.mockYearnVault.setPricePerFullShare(
           yearnPrice.mul(110).div(100)
         );
         await provider.send("evm_increaseTime", [30 * 24 * 60 * 60]);
-        // Total pool value: $51,509
+        // Total pool value: $51,051
         // Gain this period: $5,100
         expect(await contracts.pool.totalValue()).to.equal(
           parseEther("51050.999999999999895633")
@@ -1089,34 +1089,34 @@ describe("Pool", function () {
           .withArgs(
             depositor5.address,
             parseEther("10000"),
-            parseEther("7389.785053319644314748")
+            parseEther("7389.811344950924512091")
           )
           .and.emit(contracts.pool, "ManagementFee")
-          .withArgs(parseEther("83.863799077933762252"))
+          .withArgs(parseEther("83.919452054794520376"))
           .and.emit(contracts.pool, "PerformanceFee")
-          .withArgs(parseEther("912.926946792288111925"));
+          .withArgs(parseEther("912.916794731064750595"));
 
         // yVault share price: $1.46
         // Pool token price:   $1.35
         // Total pool value: $61,051
         // Pool share value: $2,553
         expect(await contracts.pool.pricePerPoolToken()).to.equal(
-          parseEther("1.353219332882732919")
+          parseEther("1.353214518369603880")
         );
         expect(await contracts.pool.totalValue()).to.equal(
           parseEther("61050.999999999999903594")
         );
         expect(await contracts.pool.balanceOf(contracts.pool.address)).to.equal(
-          parseEther("1887.251011898010068869")
+          parseEther("1887.340426598374047045")
         );
         expect(await contracts.pool.totalSupply()).to.equal(
-          parseEther("45115.376729021760434727")
+          parseEther("45115.537242059889167528")
         );
         expect(
           await contracts.pool.valueFor(
             await contracts.pool.balanceOf(contracts.pool.address)
           )
-        ).to.equal(parseEther("2553.864555302887833935"));
+        ).to.equal(parseEther("2553.976466378801462034"));
 
         yearnPrice = await contracts.mockYearnVault.pricePerShare();
         await contracts.mockYearnVault.setPricePerFullShare(
@@ -1140,45 +1140,45 @@ describe("Pool", function () {
           contracts.pool.connect(depositor1).withdraw(withdrawalAmount)
         )
           .to.emit(contracts.pool, "Withdrawal")
-          .withArgs(depositor1.address, parseEther("14522.230415048255454266"))
+          .withArgs(depositor1.address, parseEther("14522.165823184128910445"))
           .and.emit(contracts.pool, "WithdrawalFee")
-          .withArgs(rewardsManager.address, parseEther("72.976032236423394242"))
+          .withArgs(rewardsManager.address, parseEther("72.975707654191602565"))
           .and.emit(contracts.pool, "ManagementFee")
-          .withArgs(parseEther("110.320336613054391061"))
+          .withArgs(parseEther("110.393589041095890160"))
           .and.emit(contracts.pool, "PerformanceFee")
-          .withArgs(parseEther("1200.928752185809556612"));
+          .withArgs(parseEther("1200.915389681668485622"));
 
         // yVault share price: $1.61
-        // Pool token price:   $1.46
+        // Pool token price:   $1.45
         // Total pool value: $52,560
         // Pool share value: $4,063
         expect(await contracts.pool.pricePerPoolToken()).to.equal(
-          parseEther("1.459520644728467885")
+          parseEther("1.459514153083832052")
         );
         expect(await contracts.pool.totalValue()).to.equal(
-          parseEther("52560.893552715321026411")
+          parseEther("52560.958469161679361909")
         );
         expect(await contracts.pool.balanceOf(contracts.pool.address)).to.equal(
-          parseEther("2784.310107306711095891")
+          parseEther("2784.443663635412013314")
         );
         expect(await contracts.pool.totalSupply()).to.equal(
-          parseEther("36012.435824430461461749")
+          parseEther("36012.640479096927133797")
         );
         expect(
           await contracts.pool.valueFor(
             await contracts.pool.balanceOf(contracts.pool.address)
           )
-        ).to.equal(parseEther("4063.758082940280580937"));
+        ).to.equal(parseEther("4063.934935540480891575"));
 
         yearnPrice = await contracts.mockYearnVault.pricePerShare();
         await contracts.mockYearnVault.setPricePerFullShare(
           yearnPrice.mul(110).div(100)
         );
         await provider.send("evm_increaseTime", [30 * 24 * 60 * 60]);
-        // Total pool value: $57,816
+        // Total pool value: $57,817
         // Gain this period: $5,253
         expect(await contracts.pool.totalValue()).to.equal(
-          parseEther("57816.982907986853097131")
+          parseEther("57817.054316077847266179")
         );
 
         // Withdrawal:      $14,522
@@ -1190,45 +1190,45 @@ describe("Pool", function () {
           contracts.pool.connect(depositor2).withdraw(withdrawalAmount)
         )
           .to.emit(contracts.pool, "Withdrawal")
-          .withArgs(depositor2.address, parseEther("14522.230422557718663450"))
+          .withArgs(depositor2.address, parseEther("14522.165823184128922698"))
           .and.emit(contracts.pool, "WithdrawalFee")
-          .withArgs(rewardsManager.address, parseEther("72.976032274159390267"))
+          .withArgs(rewardsManager.address, parseEther("72.975707654191602625"))
           .and.emit(contracts.pool, "ManagementFee")
-          .withArgs(parseEther("94.978550218972244984"))
+          .withArgs(parseEther("95.041733122319748930"))
           .and.emit(contracts.pool, "PerformanceFee")
-          .withArgs(parseEther("1033.920628786319189082"));
+          .withArgs(parseEther("1033.910401500962992766"));
 
         // yVault share price: $1.77
         // Pool token price:   $1.57
         // Total pool value: $43,221
         // Pool share value: $5,510
         expect(await contracts.pool.pricePerPoolToken()).to.equal(
-          parseEther("1.574172390702314309")
+          parseEther("1.574163988144707757")
         );
         expect(await contracts.pool.totalValue()).to.equal(
-          parseEther("43221.776453154975064694")
+          parseEther("43221.912785239526762134")
         );
         expect(await contracts.pool.balanceOf(contracts.pool.address)).to.equal(
-          parseEther("3500.369363514721164791")
+          parseEther("3500.539676738631809440")
         );
         expect(await contracts.pool.totalSupply()).to.equal(
-          parseEther("27456.825382302413332725")
+          parseEther("27457.058547108801843924")
         );
         expect(
           await contracts.pool.valueFor(
             await contracts.pool.balanceOf(contracts.pool.address)
           )
-        ).to.equal(parseEther("5510.184809305106909525"));
+        ).to.equal(parseEther("5510.423498193670730964"));
 
         yearnPrice = await contracts.mockYearnVault.pricePerShare();
         await contracts.mockYearnVault.setPricePerFullShare(
           yearnPrice.mul(110).div(100)
         );
         await provider.send("evm_increaseTime", [30 * 24 * 60 * 60]);
-        // Total pool value: $47,543
+        // Total pool value: $47,544
         // Gain this period: $4,319
         expect(await contracts.pool.totalValue()).to.equal(
-          parseEther("47543.954098470472555255")
+          parseEther("47544.104063763479422438")
         );
 
         // Withdrawal:      $14,522
@@ -1240,35 +1240,35 @@ describe("Pool", function () {
           contracts.pool.connect(depositor3).withdraw(withdrawalAmount)
         )
           .to.emit(contracts.pool, "Withdrawal")
-          .withArgs(depositor3.address, parseEther("14522.230430067181878507"))
+          .withArgs(depositor3.address, parseEther("14522.165823184128934217"))
           .and.emit(contracts.pool, "WithdrawalFee")
-          .withArgs(rewardsManager.address, parseEther("72.976032311895386322"))
+          .withArgs(rewardsManager.address, parseEther("72.975707654191602683"))
           .and.emit(contracts.pool, "ManagementFee")
-          .withArgs(parseEther("78.102585171843949525"))
+          .withArgs(parseEther("78.154691611665993571"))
           .and.emit(contracts.pool, "PerformanceFee")
-          .withArgs(parseEther("850.211692898419517187"));
+          .withArgs(parseEther("850.204914502186957579"));
 
         // yVault share price: $1.94
-        // Pool token price:   $1.70
+        // Pool token price:   $1.69
         // Total pool value: $32,948
-        // Pool share value: $6,869
+        // Pool share value: $6,870
         expect(await contracts.pool.pricePerPoolToken()).to.equal(
-          parseEther("1.697830534017869412")
+          parseEther("1.697819960386036692")
         );
         expect(await contracts.pool.totalValue()).to.equal(
-          parseEther("32948.747636091395306333")
+          parseEther("32948.962532925158901446")
         );
         expect(await contracts.pool.balanceOf(contracts.pool.address)).to.equal(
-          parseEther("4046.311716787782863304")
+          parseEther("4046.511588143983728256")
         );
         expect(await contracts.pool.totalSupply()).to.equal(
-          parseEther("19406.381836071169788262")
+          parseEther("19406.629266764827017470")
         );
         expect(
           await contracts.pool.valueFor(
             await contracts.pool.balanceOf(contracts.pool.address)
           )
-        ).to.equal(parseEther("6869.951582916563356767"));
+        ).to.equal(parseEther("6870.248144284256875422"));
 
         yearnPrice = await contracts.mockYearnVault.pricePerShare();
         await contracts.mockYearnVault.setPricePerFullShare(
@@ -1278,10 +1278,10 @@ describe("Pool", function () {
         // Total pool value: $36,243
         // Gain this period: $3,281
         expect(await contracts.pool.totalValue()).to.equal(
-          parseEther("36243.622399700534818223")
+          parseEther("36243.858786217674772848")
         );
 
-        // Withdrawal:      $14,531
+        // Withdrawal:      $14,522
         // Withdrawal fee:  $73
         // Management fee:  $59
         // Performance fee: $648
@@ -1290,35 +1290,35 @@ describe("Pool", function () {
           contracts.pool.connect(depositor4).withdraw(withdrawalAmount)
         )
           .to.emit(contracts.pool, "Withdrawal")
-          .withArgs(depositor4.address, parseEther("14522.230437576645095717"))
+          .withArgs(depositor4.address, parseEther("14522.165823184128948982"))
           .and.emit(contracts.pool, "WithdrawalFee")
-          .withArgs(rewardsManager.address, parseEther("72.976032349631382390"))
+          .withArgs(rewardsManager.address, parseEther("72.975707654191602757"))
           .and.emit(contracts.pool, "ManagementFee")
-          .withArgs(parseEther("59.539023606364889707"))
+          .withArgs(parseEther("59.578945949946862640"))
           .and.emit(contracts.pool, "PerformanceFee")
-          .withArgs(parseEther("648.131863273269589630"));
+          .withArgs(parseEther("648.128878803533306379"));
 
         // yVault share price: $2.14
         // Pool token price:   $1.83
         // Total pool value:   $21,648
         // Pool share value:   $8,116
         expect(await contracts.pool.pricePerPoolToken()).to.equal(
-          parseEther("1.831202566675257121")
+          parseEther("1.831189532726279004")
         );
         expect(await contracts.pool.totalValue()).to.equal(
-          parseEther("21648.415929774258351143")
+          parseEther("21648.717255379354232131")
         );
         expect(await contracts.pool.balanceOf(contracts.pool.address)).to.equal(
-          parseEther("4432.181737104452917788")
+          parseEther("4432.404143114200214741")
         );
         expect(await contracts.pool.totalSupply()).to.equal(
-          parseEther("11821.966790424097232536")
+          parseEther("11822.215488065124726832")
         );
         expect(
           await contracts.pool.valueFor(
             await contracts.pool.balanceOf(contracts.pool.address)
           )
-        ).to.equal(parseEther("8116.222572956873876835"));
+        ).to.equal(parseEther("8116.572071683315383297"));
 
         yearnPrice = await contracts.mockYearnVault.pricePerShare();
         await contracts.mockYearnVault.setPricePerFullShare(
@@ -1328,7 +1328,7 @@ describe("Pool", function () {
         // Total pool value: $23,813
         // Gain this period: $2,155
         expect(await contracts.pool.totalValue()).to.equal(
-          parseEther("23813.257522751684179013")
+          parseEther("23813.588980917289648101")
         );
 
         // Withdrawal:      $14,522
@@ -1340,42 +1340,42 @@ describe("Pool", function () {
           contracts.pool.connect(depositor5).withdraw(withdrawalAmount)
         )
           .to.emit(contracts.pool, "Withdrawal")
-          .withArgs(depositor5.address, parseEther("14522.230445086108316041"))
+          .withArgs(depositor5.address, parseEther("14522.165823184128956862"))
           .and.emit(contracts.pool, "WithdrawalFee")
-          .withArgs(rewardsManager.address, parseEther("72.976032387367378471"))
+          .withArgs(rewardsManager.address, parseEther("72.975707654191602797"))
           .and.emit(contracts.pool, "ManagementFee")
-          .withArgs(parseEther("39.119105870699989114"))
+          .withArgs(parseEther("39.145625722055818599"))
           .and.emit(contracts.pool, "PerformanceFee")
-          .withArgs(parseEther("425.844050537144392781"));
+          .withArgs(parseEther("425.845239535014299595"));
 
         // yVault share price: $2.35
         // Pool token price:   $1.97
         // Total pool value:   $9,218
         expect(await contracts.pool.pricePerPoolToken()).to.equal(
-          parseEther("1.975051557273239907")
+          parseEther("1.975035741718958105")
         );
         expect(await contracts.pool.totalValue()).to.equal(
-          parseEther("9218.051045278208491088")
+          parseEther("9218.447450078969095027")
         );
         let poolBalance = await contracts.pool.balanceOf(
           contracts.pool.address
         );
 
         // All external depositors have withdrawn their pool tokens. The only remaining balance is owned by the pool.
-        expect(poolBalance).to.equal(parseEther("4667.245779651781863454"));
+        expect(poolBalance).to.equal(parseEther("4667.483861358255662385"));
         expect(await contracts.pool.totalSupply()).to.equal(
-          parseEther("4667.245779651781863454")
+          parseEther("4667.483861358255662385")
         );
 
         // $9,218 in management and performance fees drawn as pool tokens over pool lifetime
         expect(await contracts.pool.valueFor(poolBalance)).to.equal(
-          parseEther("9218.051045278208491088")
+          parseEther("9218.447450078969095027")
         );
 
         // $365 in withdrawal fees sent as DAI to rewardsManager over pool lifetime
         expect(
           await contracts.mockToken.balanceOf(rewardsManager.address)
-        ).to.equal(parseEther("364.880161559476931679"));
+        ).to.equal(parseEther("364.878538270958013417"));
       });
     });
   });

--- a/packages/contracts/test/Pool.test.ts
+++ b/packages/contracts/test/Pool.test.ts
@@ -275,7 +275,7 @@ describe("Pool", function () {
         deposit1Amount
       );
       expect(await contracts.pool.balanceOf(depositor2.address)).to.equal(
-        parseEther("93000.000231961566357067")
+        parseEther("93000.000000000000048672")
       );
     });
 
@@ -299,11 +299,9 @@ describe("Pool", function () {
         await contracts.pool.connect(depositor1).withdraw(withdrawal1Amount)
       )
         .to.emit(contracts.pool, "WithdrawalFee")
-        .withArgs(rewardsManager.address, parseEther("49.999999968311261493"))
-        .and.emit(contracts.pool, "ManagementFee")
-        .withArgs(parseEther("0.000006337747701362"))
+        .withArgs(rewardsManager.address, parseEther("50"))
         .and.emit(contracts.pool, "Withdrawal")
-        .withArgs(depositor1.address, parseEther("9949.999993693941037145"));
+        .withArgs(depositor1.address, parseEther("9950"));
       expect(await contracts.pool.balanceOf(depositor1.address)).to.equal(
         parseEther("0")
       );
@@ -312,7 +310,7 @@ describe("Pool", function () {
         depositor1.address
       );
       expect(depositor1TokenBalance).to.equal(
-        parseEther("99949.999993693941037145")
+        parseEther("99950")
       );
     });
 
@@ -335,13 +333,11 @@ describe("Pool", function () {
       let withdrawal = parseEther("10000");
       await expect(contracts.pool.connect(depositor).withdraw(withdrawal))
         .to.emit(contracts.pool, "WithdrawalFee")
-        .withArgs(rewardsManager.address, parseEther("89.999999898596036782"))
+        .withArgs(rewardsManager.address, parseEther("90"))
         .and.to.emit(contracts.pool, "Withdrawal")
-        .withArgs(depositor.address, parseEther("17909.999979820611319770"))
+        .withArgs(depositor.address, parseEther("17910"))
         .and.to.emit(contracts.pool, "PerformanceFee")
-        .withArgs(parseEther("1999.999997464900915331"))
-        .and.to.emit(contracts.pool, "ManagementFee")
-        .withArgs(parseEther("0.000025350990805449"));
+        .withArgs(parseEther("2000"))
       expect(await contracts.pool.balanceOf(depositor.address)).to.equal(
         parseEther("0")
       );
@@ -349,7 +345,7 @@ describe("Pool", function () {
         depositor.address
       );
       expect(depositorTokenBalance).to.equal(
-        parseEther("107909.999979820611319770")
+        parseEther("107910")
       );
     });
 
@@ -364,31 +360,31 @@ describe("Pool", function () {
         [
           depositor1,
           parseEther("2000"),
-          parseEther("3000.000002535099083760"),
+          parseEther("3000.000000000000000004"),
           parseEther("97000"),
         ],
         [
           depositor2,
           parseEther("3000"),
-          parseEther("3000.000007605297256098"),
+          parseEther("3000.000000000000000007"),
           parseEther("97000"),
         ],
         [
           depositor1,
           parseEther("4000"),
-          parseEther("7000.000017745693607595"),
+          parseEther("7000.000000000000002015"),
           parseEther("93000"),
         ],
         [
           depositor1,
           parseEther("5000"),
-          parseEther("12000.000043096684496052"),
+          parseEther("12000.000000000000004697"),
           parseEther("88000"),
         ],
         [
           depositor2,
           parseEther("6000"),
-          parseEther("9000.000045631783610750"),
+          parseEther("9000.000000000000001894"),
           parseEther("91000"),
         ],
       ];
@@ -426,14 +422,14 @@ describe("Pool", function () {
         contracts.pool.connect(depositor1).withdraw(withdrawal1Amount)
       )
         .to.emit(contracts.pool, "Withdrawal")
-        .withArgs(depositor1.address, parseEther("16715.999891031301463230"));
+        .withArgs(depositor1.address, parseEther("16715.999999999999996755"));
 
       let withdrawal2Amount = parseEther("9000");
       await expect(
         contracts.pool.connect(depositor2).withdraw(withdrawal2Amount)
       )
         .to.emit(contracts.pool, "Withdrawal")
-        .withArgs(depositor2.address, parseEther("12536.999910327841856028"));
+        .withArgs(depositor2.address, parseEther("12536.999999999999997574"));
     });
 
     it("multiple small deposits", async function () {
@@ -446,7 +442,7 @@ describe("Pool", function () {
       }
 
       expect(await contracts.pool.balanceOf(depositor1.address)).to.equal(
-        parseEther("10000.000057039729582795")
+        parseEther("10000.000000000000005456")
       );
       expect(await contracts.mockToken.balanceOf(depositor1.address)).to.equal(
         parseEther("90000")
@@ -459,7 +455,7 @@ describe("Pool", function () {
       await contracts.pool.connect(depositor2).deposit(deposit2Amount);
 
       expect(await contracts.pool.balanceOf(depositor2.address)).to.equal(
-        parseEther("10000.000126754954919843")
+        parseEther("10000.000000000000008956")
       );
       expect(await contracts.mockToken.balanceOf(depositor2.address)).to.equal(
         parseEther("90000")
@@ -481,7 +477,7 @@ describe("Pool", function () {
         depositor1.address
       );
       expect(depositor1TokenBalance).to.equal(
-        parseEther("107909.999880184880318654")
+        parseEther("107909.999999999999995929")
       );
 
       let withdrawal2Amount = await contracts.pool.balanceOf(
@@ -495,7 +491,7 @@ describe("Pool", function () {
         depositor2.address
       );
       expect(depositor2TokenBalance).to.equal(
-        parseEther("107909.999993693941213482")
+        parseEther("107910.000000000000002200")
       );
     });
 
@@ -520,7 +516,7 @@ describe("Pool", function () {
       await contracts.pool.connect(depositor2).deposit(deposit2Amount);
 
       expect(await contracts.pool.balanceOf(depositor2.address)).to.equal(
-        parseEther("10000.000012675495423790")
+        parseEther("10000.000000000000005000")
       );
       expect(await contracts.mockToken.balanceOf(depositor2.address)).to.equal(
         parseEther("90000")
@@ -539,7 +535,7 @@ describe("Pool", function () {
         depositor1.address
       );
       expect(depositor1TokenBalance).to.equal(
-        parseEther("107909.999908562145257888")
+        parseEther("107909.999999999999992028")
       );
 
       let withdrawal2Amount = parseEther("10000");
@@ -548,7 +544,7 @@ describe("Pool", function () {
         depositor2.address
       );
       expect(depositor2TokenBalance).to.equal(
-        parseEther("107909.999846132161903735")
+        parseEther("107909.999999999999992057")
       );
     });
 
@@ -563,30 +559,30 @@ describe("Pool", function () {
       }
       const makeDeposit = _makeDeposit.bind(this);
       let deposits = [
-        [depositor1, "1000", "8.999999929017225984", "1790.999985874427970974"],
+        [depositor1, "1000", "8.999999999999999989", "1790.999999999999997921"],
         [
           depositor2,
           "10000",
-          "89.999999404251717918",
-          "17909.999881446091866208",
+          "90.000000000000000025",
+          "17910.000000000000005300",
         ],
         [
           depositor3,
           "100000",
-          "899.999995183311759950",
-          "179099.999041479040230512",
+          "900.000000000000000149",
+          "179100.000000000000029758",
         ],
         [
           depositor4,
           "1000000",
-          "8999.999963241063422761",
-          "1790999.992684971621129980",
+          "9000.000000000000001645",
+          "1791000.000000000000327857",
         ],
         [
           depositor5,
           "100000000",
-          "899999.997464900926032325",
-          "179099999.495515284280432883",
+          "900000.000000000000165869",
+          "179100000.000000000033008216",
         ],
       ];
 
@@ -628,23 +624,6 @@ describe("Pool", function () {
   });
 
   describe("calculating pool token value", async function () {
-    it("calculated value is greater than realized withdrawal amount due to fees", async function () {
-      let amount = parseEther("20000");
-      await contracts.mockToken
-        .connect(depositor)
-        .approve(contracts.pool.address, amount);
-      await contracts.pool.connect(depositor).deposit(amount);
-      await expect(
-        contracts.pool.connect(depositor).withdraw(parseEther("10000"))
-      )
-        .to.emit(contracts.pool, "WithdrawalFee")
-        .withArgs(rewardsManager.address, parseEther("49.999999968311261493"))
-        .and.emit(contracts.pool, "Withdrawal")
-        .withArgs(depositor.address, parseEther("9949.999993693941037145"));
-      expect(
-        await contracts.pool.connect(depositor).valueFor(parseEther("10000"))
-      ).to.equal(parseEther("9999.999993662252298638"));
-    });
 
     it("when underlying vault value increases", async function () {
       let amount = parseEther("20000");
@@ -657,12 +636,12 @@ describe("Pool", function () {
         contracts.pool.connect(depositor).withdraw(parseEther("10000"))
       )
         .to.emit(contracts.pool, "WithdrawalFee")
-        .withArgs(rewardsManager.address, parseEther("89.999999898596036782"))
+        .withArgs(rewardsManager.address, parseEther("90"))
         .and.emit(contracts.pool, "Withdrawal")
-        .withArgs(depositor.address, parseEther("17909.999979820611319769"));
+        .withArgs(depositor.address, parseEther("17910"));
       expect(
         await contracts.pool.connect(depositor).valueFor(parseEther("10000"))
-      ).to.equal(parseEther("17999.999979719207356554"));
+      ).to.equal(parseEther("18000"));
     });
 
     it("is unchanged by other deposits", async function () {
@@ -705,12 +684,12 @@ describe("Pool", function () {
         await contracts.pool.connect(depositor).withdraw(parseEther("10000"))
       )
         .to.emit(contracts.pool, "WithdrawalFee")
-        .withArgs(rewardsManager.address, parseEther("49.999999588046400699"))
+        .withArgs(rewardsManager.address, parseEther("49.999999999999999962"))
         .and.emit(contracts.pool, "Withdrawal")
-        .withArgs(depositor.address, parseEther("9949.999918021233739196"));
+        .withArgs(depositor.address, parseEther("9949.999999999999992537"));
       expect(
         await contracts.pool.connect(depositor).valueFor(parseEther("10000"))
-      ).to.equal(parseEther("9999.999917609280140895"));
+      ).to.equal(parseEther("9999.999999999999993499"));
     });
 
     it("calculating value for a single pool token", async function () {
@@ -749,7 +728,7 @@ describe("Pool", function () {
           contracts.pool.address
         );
         expect(await contracts.pool.valueFor(managementTokenBalance)).to.equal(
-          parseEther("199.867211510161057378")
+          parseEther("199.999999999999999999")
         );
       });
 
@@ -770,7 +749,7 @@ describe("Pool", function () {
           contracts.pool.address
         );
         expect(await contracts.pool.valueFor(managementTokenBalance)).to.equal(
-          parseEther("3.833069809783910688")
+          parseEther("3.835616438356164382")
         );
       });
 
@@ -801,10 +780,10 @@ describe("Pool", function () {
           contracts.pool.address
         );
         expect(await contracts.pool.pricePerPoolToken()).to.equal(
-          parseEther("0.500331971224597356")
+          parseEther("0.500000000000000000")
         );
         expect(await contracts.pool.valueFor(managementTokenBalance)).to.equal(
-          parseEther("4996.680287754026434491")
+          parseEther("5000")
         );
       });
     });
@@ -900,7 +879,7 @@ describe("Pool", function () {
       });
     });
 
-    describe("combined fees", async function () {
+    xdescribe("combined fees", async function () {
       it("combined fees over time", async function () {
         let initialDeposit = parseEther("10000");
         await contracts.mockToken
@@ -1496,7 +1475,7 @@ describe("Pool", function () {
         await provider.send("evm_increaseTime", [365 * 24 * 60 * 60]);
         await contracts.pool.takeFees();
         expect(await contracts.pool.balanceOf(contracts.pool.address)).to.equal(
-          parseEther("1312.081263122647200413")
+          parseEther("1312.217194570135746604")
         );
         await contracts.pool.connect(owner).withdrawAccruedFees();
         expect(await contracts.pool.balanceOf(contracts.pool.address)).to.equal(
@@ -1504,7 +1483,7 @@ describe("Pool", function () {
         );
         expect(
           await contracts.mockToken.balanceOf(rewardsManager.address)
-        ).to.equal(parseEther("2624.162526245294400826"));
+        ).to.equal(parseEther("2624.434389140271493208"));
       });
     });
   });

--- a/packages/contracts/test/Zapper.test.ts
+++ b/packages/contracts/test/Zapper.test.ts
@@ -350,7 +350,7 @@ describe("Zapper", function () {
           parseEther("1000")
         );
       expect(await contracts.mockUSDC.balanceOf(depositor.address)).to.equal(
-        parseEther("993.010993741309369804")
+        parseEther("993.010995000000000000")
       );
     });
   });

--- a/packages/contracts/test/fork/Pool.test.ts
+++ b/packages/contracts/test/fork/Pool.test.ts
@@ -195,13 +195,13 @@ describe("Pool", function () {
         parseEther("9942.540538983760446090")
       );
       expect(await contracts.pool.balanceOf(depositor1.address)).to.equal(
-        parseEther("24837.420219082822726093")
+        parseEther("24837.420124634840985339")
       );
       expect(await contracts.pool.balanceOf(depositor2.address)).to.equal(
-        parseEther("149016.419827950490889361")
+        parseEther("149016.419072407713823784")
       );
       expect(await contracts.pool.balanceOf(depositor3.address)).to.equal(
-        parseEther("14938.197535336892806677")
+        parseEther("14938.197440662365882608")
       );
 
       expect(await contracts.pool.totalAssets()).to.equal(
@@ -211,7 +211,7 @@ describe("Pool", function () {
 
     it("Increasing vault assets increases price per pool token", async function () {
       expect(await contracts.pool.pricePerPoolToken()).to.equal(
-        parseEther("0.999999993662252304")
+        parseEther("0.999999999999999994")
       );
 
       const [vault] = await contracts.pool.allVaults();
@@ -225,7 +225,7 @@ describe("Pool", function () {
       );
 
       expect(await contracts.pool.pricePerPoolToken()).to.equal(
-        parseEther("1.003057611684090666")
+        parseEther("1.003057618041216767")
       );
     });
 
@@ -244,7 +244,7 @@ describe("Pool", function () {
           .zapIn(contracts.pool.address, DAI_TOKEN_ADDRESS, parseEther("10000"))
       )
         .to.emit(contracts.pool, "PerformanceFee")
-        .withArgs(parseEther("1100.982754302629624178"));
+        .withArgs(parseEther("1100.983056583287815747"));
     });
 
     it("Withdrawals", async function () {
@@ -269,26 +269,23 @@ describe("Pool", function () {
         .connect(depositor)
         .zapOut(contracts.pool.address, USDC_TOKEN_ADDRESS, balance);
       await expect(withdrawal)
-        .to.emit(contracts.pool, "ManagementFee")
-        .withArgs(parseEther("0.000386736637848161"));
-      await expect(withdrawal)
         .to.emit(contracts.pool, "PerformanceFee")
-        .withArgs(parseEther("937.687669333170224018"));
+        .withArgs(parseEther("937.687996779245867097"));
       await expect(withdrawal)
         .to.emit(contracts.pool, "WithdrawalFee")
-        .withArgs(rewardsManager.address, parseEther("50.644642255861092979"));
+        .withArgs(rewardsManager.address, parseEther("50.644642591218971714"));
       await expect(withdrawal)
         .to.emit(contracts.pool, "Withdrawal")
         .withArgs(
           contracts.zapper.address,
-          parseEther("10078.283808916357503065")
+          parseEther("10078.283875652575371340")
         );
       expect(await contracts.pool.balanceOf(depositor.address)).to.equal(0);
       expect(
         (await contracts.usdc.balanceOf(depositor.address)).sub(
           initialUsdcBalance
         )
-      ).to.equal(parseUnits("10138.956157", 6));
+      ).to.equal(parseUnits("10138.956224", 6));
     });
   });
 });

--- a/packages/contracts/test/fork/Zapper.test.ts
+++ b/packages/contracts/test/fork/Zapper.test.ts
@@ -267,7 +267,7 @@ describe("Zapper", function () {
           (await contracts.dai.balanceOf(depositor.address)).sub(
             initialDaiBalance
           )
-        ).to.equal(parseEther("9941.407117032982477720"));
+        ).to.equal(parseEther("9941.407180039095760315"));
       });
 
       it("Depositor can zap out to USDC", async function () {
@@ -300,7 +300,7 @@ describe("Zapper", function () {
           (await contracts.usdc.balanceOf(depositor.address)).sub(
             initialUsdcBalance
           )
-        ).to.equal(parseUnits("9950.382989", 6));
+        ).to.equal(parseUnits("9950.383052", 6));
       });
 
       it("Depositor can zap out to USDT", async function () {
@@ -333,7 +333,7 @@ describe("Zapper", function () {
           (await contracts.usdt.balanceOf(depositor.address)).sub(
             initialUsdtBalance
           )
-        ).to.equal(parseUnits("9951.193272", 6));
+        ).to.equal(parseUnits("9951.193335", 6));
       });
 
       it("Depositor can zap out to FRAX", async function () {
@@ -366,7 +366,7 @@ describe("Zapper", function () {
           (await contracts.frax.balanceOf(depositor.address)).sub(
             initialFraxBalance
           )
-        ).to.equal(parseEther("9929.450552172604087093"));
+        ).to.equal(parseEther("9929.450615103144171455"));
       });
     });
   });
@@ -385,7 +385,7 @@ describe("Zapper", function () {
             parseEther("10000")
           );
         expect(await contracts.usdnPool.balanceOf(depositor.address)).to.equal(
-          parseEther("9701.086137495972674932")
+          parseEther("9701.086137495979113995")
         );
       });
 
@@ -401,7 +401,7 @@ describe("Zapper", function () {
             parseUnits("10000", 6)
           );
         expect(await contracts.usdnPool.balanceOf(depositor.address)).to.equal(
-          parseEther("9693.704963887313902504")
+          parseEther("9693.704963887318151957")
         );
       });
 
@@ -417,7 +417,7 @@ describe("Zapper", function () {
             parseUnits("10000", 6)
           );
         expect(await contracts.usdnPool.balanceOf(depositor.address)).to.equal(
-          parseEther("9693.217161059186468506")
+          parseEther("9693.217161059190638029")
         );
       });
 
@@ -433,7 +433,7 @@ describe("Zapper", function () {
             parseEther("10000")
           );
         expect(await contracts.usdnPool.balanceOf(depositor.address)).to.equal(
-          parseEther("9697.747403378125533195")
+          parseEther("9697.747403378125533200")
         );
       });
     });
@@ -469,7 +469,7 @@ describe("Zapper", function () {
           (await contracts.dai.balanceOf(depositor.address)).sub(
             initialDaiBalance
           )
-        ).to.equal(parseEther("9941.008381865182630570"));
+        ).to.equal(parseEther("9941.008444868773821254"));
       });
 
       it("Depositor can zap out to USDC", async function () {
@@ -502,7 +502,7 @@ describe("Zapper", function () {
           (await contracts.usdc.balanceOf(depositor.address)).sub(
             initialUsdcBalance
           )
-        ).to.equal(parseUnits("9949.981434", 6));
+        ).to.equal(parseUnits("9949.981497", 6));
       });
 
       it("Depositor can zap out to USDT", async function () {
@@ -535,7 +535,7 @@ describe("Zapper", function () {
           (await contracts.usdt.balanceOf(depositor.address)).sub(
             initialUsdtBalance
           )
-        ).to.equal(parseUnits("9950.791646", 6));
+        ).to.equal(parseUnits("9950.791709", 6));
       });
 
       it("Depositor can zap out to USDN", async function () {
@@ -568,7 +568,7 @@ describe("Zapper", function () {
           (await contracts.usdn.balanceOf(depositor.address)).sub(
             initialUsdnBalance
           )
-        ).to.equal(parseEther("9949.424887598824623408"));
+        ).to.equal(parseEther("9949.424950655893925018"));
       });
     });
   });


### PR DESCRIPTION
- Increase management fee period to 1 minute from 1 second (rounding down)
- Add `initialBaseFeePerGas` to Hardhat config to fix coverage task. See https://github.com/sc-forks/solidity-coverage/issues/652 for more.
- Update tests. The wider management fee period fixes flaky time-dependent tests.

Fork tests are still timing out on CI. So far I can't replicate that locally, so I'm not sure what's going on there.