### PR TITLE
Landing page navigation margin

### DIFF
--- a/packages/app/pages/index.tsx
+++ b/packages/app/pages/index.tsx
@@ -590,6 +590,7 @@ const IndexPage = () => {
         {menuVisible && (
           <div className="absolute z-10 w-screen">
             <div className="relative mx-auto mt-4 w-11/12 rounded-lg shadow-md bg-white px-4 pt-4 pb-6">
+
               <div className="flex flex-row justify-between items-center">
                 <Link href="/" passHref>
                   <a>
@@ -606,7 +607,7 @@ const IndexPage = () => {
                   onClick={(e) => toggleMenu(false)}
                 />
               </div>
-              <div className="flex flex-col space-y-4 mt-8">
+              <div className="flex flex-col space-y-4 mt-4">
                 {/*<Link href="/" passHref>
               <a className="font-medium text-base hover:text-blue-600">
                 About us
@@ -661,9 +662,8 @@ const IndexPage = () => {
           </nav>
         </header>
         <section className="max-h-screen min-h-full">
-          <div className="bg-primary w-full h-12"></div>
           <div
-            className="bg-hero-pattern flex-shrink-0 flex-grow-0 w-full h-full"
+            className="bg-hero-pattern flex-shrink-0 flex-grow-0 w-full h-full pt-6 md:pt-10"
             style={{
               backgroundRepeat: 'no-repeat',
               backgroundSize: 'cover',


### PR DESCRIPTION
Reduce gap between "Whitepaper" and logo in navbar and reduce gap between navbar and image for mobile.

![image](https://user-images.githubusercontent.com/3315297/133084709-657e578a-0cef-4628-a0c6-af1263441788.png)
![image](https://user-images.githubusercontent.com/3315297/133084727-2a47c102-bcc6-4495-8d45-e4a8f3b49a8c.png)
