### PR TITLE
Fix the anchor links problem in generated contracts' documentations

### DIFF
--- a/packages/contracts/docgen/contract.hbs
+++ b/packages/contracts/docgen/contract.hbs
@@ -11,7 +11,7 @@
 ## Functions:
 {{#ownFunctions}}
 {{#if (or (eq visibility "public") (eq visibility "external"))}}
-- [`{{name}}()`](#{{name}})
+- [`{{name}}()`](#{{anchor}})
 {{/if}}
 {{/ownFunctions}}
 {{/if}}
@@ -37,7 +37,7 @@
 
 {{#if (or (eq visibility "public") (eq visibility "external"))}}
 
-### <a name="{{anchor}}"></a> {{name}}() 
+### <a name="{{anchor}}"></a> {{name}}() {#{{anchor}}}
 
 ```
 {{name}}({{args}}) {{visibility}} {{#if outputs}} returns ({{outputs}}){{/if}}
@@ -71,7 +71,7 @@
 
 ## Events
 {{#ownEvents}}
-### <a name="{{anchor}}"></a> {{name}}
+### <a name="{{anchor}}"></a> {{name}} {#{{anchor}}}
 ```
 {{name}}({{args}})
 ```
@@ -93,7 +93,7 @@
 {{#if ownModifiers}}
 ## Modifiers
 {{#ownModifiers}}
-### <a name="{{anchor}}"></a> `{{name}}()`
+### <a name="{{anchor}}"></a> `{{name}}()` {#{{anchor}}}
 ```
 {{name}}({{args}})
 ```

--- a/packages/contracts/docgen/contract.hbs
+++ b/packages/contracts/docgen/contract.hbs
@@ -37,7 +37,7 @@
 
 {{#if (or (eq visibility "public") (eq visibility "external"))}}
 
-### <a name="{{name}}"></a> {{name}}() {#{{name}}_}
+### <a name="{{name}}_"></a> {{name}}() {#{{name}}_}
 
 ```
 {{name}}({{args}}) {{visibility}} {{#if outputs}} returns ({{outputs}}){{/if}}
@@ -71,7 +71,7 @@
 
 ## Events
 {{#ownEvents}}
-### <a name="{{name}}"></a> {{name}} {#{{name}}_}
+### <a name="{{name}}_"></a> {{name}} {#{{name}}_}
 ```
 {{name}}({{args}})
 ```
@@ -93,7 +93,7 @@
 {{#if ownModifiers}}
 ## Modifiers
 {{#ownModifiers}}
-### <a name="{{name}}"></a> `{{name}}()` {#{{name}}_}
+### <a name="{{name}}_"></a> `{{name}}()` {#{{name}}_}
 ```
 {{name}}({{args}})
 ```

--- a/packages/contracts/docgen/contract.hbs
+++ b/packages/contracts/docgen/contract.hbs
@@ -11,7 +11,7 @@
 ## Functions:
 {{#ownFunctions}}
 {{#if (or (eq visibility "public") (eq visibility "external"))}}
-- [`{{name}}()`](#{{anchor}})
+- [`{{name}}()`](#{{name}})
 {{/if}}
 {{/ownFunctions}}
 {{/if}}

--- a/packages/contracts/docgen/contract.hbs
+++ b/packages/contracts/docgen/contract.hbs
@@ -11,7 +11,7 @@
 ## Functions:
 {{#ownFunctions}}
 {{#if (or (eq visibility "public") (eq visibility "external"))}}
-- [`{{name}}()`](#{{anchor}})
+- [`{{name}}()`](#{{name}}_)
 {{/if}}
 {{/ownFunctions}}
 {{/if}}
@@ -19,14 +19,14 @@
 {{#if ownEvents}}
 ## Events:
 {{#ownEvents}}
-- [`{{name}}`](#{{anchor}})
+- [`{{name}}`](#{{name}}_)
 {{/ownEvents}}
 {{/if}}
 
 {{#if ownModifiers}}
 ## Modifiers:
 {{#ownModifiers}}
-- [`{{name}}()`](#{{anchor}})
+- [`{{name}}()`](#{{name}}_)
 {{/ownModifiers}}
 {{/if}}
 
@@ -37,7 +37,7 @@
 
 {{#if (or (eq visibility "public") (eq visibility "external"))}}
 
-### <a name="{{anchor}}"></a> {{name}}() {#{{anchor}}}
+### <a name="{{name}}"></a> {{name}}() {#{{name}}_}
 
 ```
 {{name}}({{args}}) {{visibility}} {{#if outputs}} returns ({{outputs}}){{/if}}
@@ -71,7 +71,7 @@
 
 ## Events
 {{#ownEvents}}
-### <a name="{{anchor}}"></a> {{name}} {#{{anchor}}}
+### <a name="{{name}}"></a> {{name}} {#{{name}}_}
 ```
 {{name}}({{args}})
 ```
@@ -93,7 +93,7 @@
 {{#if ownModifiers}}
 ## Modifiers
 {{#ownModifiers}}
-### <a name="{{anchor}}"></a> `{{name}}()` {#{{anchor}}}
+### <a name="{{name}}"></a> `{{name}}()` {#{{name}}_}
 ```
 {{name}}({{args}})
 ```


### PR DESCRIPTION
This PR fixes the anchor links problem that we discussed in discord.

Live preview: https://sooptq.gitbook.io/popcorndao-workspace-develop/