### PR TITLE
Ben vaults refactor

### DIFF
--- a/packages/contracts/contracts/BeneficiaryVaults.sol
+++ b/packages/contracts/contracts/BeneficiaryVaults.sol
@@ -252,10 +252,6 @@ contract BeneficiaryVaults is IBeneficiaryVaults, Ownable, ReentrancyGuard {
 
   /* ========== RESTRICTED FUNCTIONS ========== */
 
-  function getOpenVaultCount() public view returns (uint8) {
-    return _getOpenVaultCount();
-  }
-
   function _getOpenVaultCount() internal view returns (uint8) {
     uint8 _openVaultCount = 0;
     bool zeroWasCounted = false;

--- a/packages/contracts/contracts/BeneficiaryVaults.sol
+++ b/packages/contracts/contracts/BeneficiaryVaults.sol
@@ -35,7 +35,7 @@ contract BeneficiaryVaults is IBeneficiaryVaults, Ownable, ReentrancyGuard {
   IERC20 public immutable pop;
   IBeneficiaryRegistry public beneficiaryRegistry;
   uint256 public totalDistributedBalance = 0;
-  Vault[3] public vaults;
+  mapping(bytes32 => Vault) public vaults;
 
   /* ========== EVENTS ========== */
 
@@ -56,7 +56,7 @@ contract BeneficiaryVaults is IBeneficiaryVaults, Ownable, ReentrancyGuard {
 
   /* ========== VIEWS ========== */
 
-  function getVault(uint8 vaultId_)
+  function getVault(bytes32 vaultId_)
     public
     view
     _vaultExists(vaultId_)
@@ -76,7 +76,7 @@ contract BeneficiaryVaults is IBeneficiaryVaults, Ownable, ReentrancyGuard {
     status = vault.status;
   }
 
-  function hasClaimed(uint8 vaultId_, address beneficiary_)
+  function hasClaimed(bytes32 vaultId_, address beneficiary_)
     public
     view
     _vaultExists(vaultId_)
@@ -85,7 +85,7 @@ contract BeneficiaryVaults is IBeneficiaryVaults, Ownable, ReentrancyGuard {
     return vaults[vaultId_].claimed[beneficiary_];
   }
 
-  function vaultExists(uint8 vaultId_) public view override returns (bool) {
+  function vaultExists(bytes32 vaultId_) public view override returns (bool) {
     return vaultId_ < 3 && vaults[vaultId_].merkleRoot != "";
   }
 
@@ -97,7 +97,7 @@ contract BeneficiaryVaults is IBeneficiaryVaults, Ownable, ReentrancyGuard {
    * @param merkleRoot_ Merkle root to support claims
    * @dev Vault cannot be initialized if it is currently in an open state, otherwise existing data is reset*
    */
-  function openVault(uint8 vaultId_, bytes32 merkleRoot_)
+  function openVault(bytes32 vaultId_, bytes32 merkleRoot_)
     public
     override
     onlyOwner
@@ -125,7 +125,7 @@ contract BeneficiaryVaults is IBeneficiaryVaults, Ownable, ReentrancyGuard {
    * @dev Vault must be in an open state
    * @param vaultId_ Vault ID in range 0-2
    */
-  function closeVault(uint8 vaultId_)
+  function closeVault(bytes32 vaultId_)
     public
     override
     onlyOwner
@@ -156,7 +156,7 @@ contract BeneficiaryVaults is IBeneficiaryVaults, Ownable, ReentrancyGuard {
    * @return Returns boolean true or false if claim is valid
    */
   function verifyClaim(
-    uint8 vaultId_,
+    bytes32 vaultId_,
     bytes32[] memory proof_,
     address beneficiary_,
     uint256 share_
@@ -185,7 +185,7 @@ contract BeneficiaryVaults is IBeneficiaryVaults, Ownable, ReentrancyGuard {
    * @param share_ Beneficiary expected share encoded in leaf element
    */
   function claimReward(
-    uint8 vaultId_,
+    bytes32 vaultId_,
     bytes32[] memory proof_,
     address beneficiary_,
     uint256 share_
@@ -281,7 +281,7 @@ contract BeneficiaryVaults is IBeneficiaryVaults, Ownable, ReentrancyGuard {
 
   /* ========== MODIFIERS ========== */
 
-  modifier _vaultExists(uint8 vaultId_) {
+  modifier _vaultExists(bytes32 vaultId_) {
     require(vaultExists(vaultId_), "vault must exist");
     _;
   }

--- a/packages/contracts/contracts/GrantElections.sol
+++ b/packages/contracts/contracts/GrantElections.sol
@@ -219,9 +219,10 @@ contract GrantElections is ParticipationReward {
       }
     }
     address beneficiaryVault = region.regionVaults(_region);
-    if (IBeneficiaryVaults(beneficiaryVault).vaultExists(_term)) {
-      IBeneficiaryVaults(beneficiaryVault).closeVault(_term);
-    }
+    uint256 activeVaultId = IBeneficiaryVaults(beneficiaryVault).activeVaults(
+      _term
+    );
+    IBeneficiaryVaults(beneficiaryVault).closeVault(activeVaultId);
 
     uint256 electionId = elections.length;
     activeElections[_region][_term] = electionId;
@@ -444,6 +445,7 @@ contract GrantElections is ParticipationReward {
 
     address beneficiaryVault = region.regionVaults(election.region);
     IBeneficiaryVaults(beneficiaryVault).openVault(
+      _electionId,
       uint8(election.electionTerm),
       _merkleRoot
     );

--- a/packages/contracts/contracts/GrantElections.sol
+++ b/packages/contracts/contracts/GrantElections.sol
@@ -222,7 +222,9 @@ contract GrantElections is ParticipationReward {
     uint256 activeVaultId = IBeneficiaryVaults(beneficiaryVault).activeVaults(
       _term
     );
-    IBeneficiaryVaults(beneficiaryVault).closeVault(activeVaultId);
+    if (IBeneficiaryVaults(beneficiaryVault).vaultCanBeClosed(_term)) {
+      IBeneficiaryVaults(beneficiaryVault).closeVault(activeVaultId);
+    }
 
     uint256 electionId = elections.length;
     activeElections[_region][_term] = electionId;

--- a/packages/contracts/contracts/Interfaces/IBeneficiaryVaults.sol
+++ b/packages/contracts/contracts/Interfaces/IBeneficiaryVaults.sol
@@ -3,11 +3,15 @@
 pragma solidity >=0.7.0 <0.8.0;
 
 interface IBeneficiaryVaults {
-  function vaultExists(uint8 vaultId_) external view returns (bool);
+  function activeVaults(uint256 term) external view returns (uint256);
 
-  function openVault(uint8 vaultId_, bytes32 merkleRoot_) external;
+  function openVault(
+    uint256 vaultId_,
+    uint8 electionTerm_,
+    bytes32 merkleRoot_
+  ) external;
 
-  function closeVault(uint8 vaultId_) external;
+  function closeVault(uint256 vaultId_) external;
 
   function allocateRewards() external;
 }

--- a/packages/contracts/contracts/Interfaces/IBeneficiaryVaults.sol
+++ b/packages/contracts/contracts/Interfaces/IBeneficiaryVaults.sol
@@ -5,6 +5,8 @@ pragma solidity >=0.7.0 <0.8.0;
 interface IBeneficiaryVaults {
   function activeVaults(uint256 term) external view returns (uint256);
 
+  function vaultCanBeClosed(uint8 term) external view returns (bool);
+
   function openVault(
     uint256 vaultId_,
     uint8 electionTerm_,

--- a/packages/contracts/test/BeneficiaryVaults.test.ts
+++ b/packages/contracts/test/BeneficiaryVaults.test.ts
@@ -455,7 +455,7 @@ describe("BeneficiaryVaults", function () {
               expect(vaultData.totalAllocated).to.equal(
                 firstReward.add(secondReward)
               );
-              expect(vaultData.currentBalance).to.equal(0);
+              expect(vaultData.status).to.be.equal(VaultStatus.Closed);
             });
           });
           describe("open vault 1", function () {
@@ -490,7 +490,7 @@ describe("BeneficiaryVaults", function () {
               await contracts.beneficiaryVaults.allocateRewards();
               const vault0 = await contracts.beneficiaryVaults.getVault(0);
               expect(vault0.totalAllocated).to.equal(
-                firstReward.add(parseEther("0.5"))
+                firstReward.add(secondReward).add(parseEther("0.5"))
               );
               expect(vault0.currentBalance).to.equal(
                 firstReward.add(parseEther("0.5"))

--- a/packages/contracts/test/BeneficiaryVaults.test.ts
+++ b/packages/contracts/test/BeneficiaryVaults.test.ts
@@ -130,7 +130,7 @@ describe("BeneficiaryVaults", function () {
     it("emits a VaultOpened event", async function () {
       expect(result)
         .to.emit(contracts.beneficiaryVaults, "VaultOpened")
-        .withArgs(0, merkleRoot);
+        .withArgs(0, 0, merkleRoot);
     });
 
     it("vault has expected values", async function () {
@@ -145,31 +145,6 @@ describe("BeneficiaryVaults", function () {
       ).to.be.false;
       expect(
         await contracts.beneficiaryVaults.hasClaimed(0, beneficiary2.address)
-      ).to.be.false;
-    });
-
-    it("emits expected events", async function () {
-      expect(result)
-        .to.emit(contracts.beneficiaryVaults, "VaultOpened")
-        .withArgs(0, merkleRoot);
-    });
-
-    it("vault has expected values", async function () {
-      const vaultData = await contracts.beneficiaryVaults.getVault(0);
-      expect(vaultData.totalAllocated).to.equal(0);
-      expect(vaultData.currentBalance).to.equal(0);
-      expect(vaultData.unclaimedShare).to.equal(parseEther("100"));
-      expect(vaultData.merkleRoot).to.equal(merkleRoot);
-      expect(vaultData.status).to.equal(VaultStatus.Open);
-      expect(
-        await contracts.beneficiaryVaults.hasClaimed(0, beneficiary1.address)
-      ).to.be.false;
-      expect(
-        await contracts.beneficiaryVaults.hasClaimed(
-          0,
-
-          beneficiary2.address
-        )
       ).to.be.false;
     });
 
@@ -200,233 +175,244 @@ describe("BeneficiaryVaults", function () {
           )
       ).to.be.revertedWith("No reward");
     });
-    describe("deposits reward and distribute it", function () {
-      beforeEach(async function () {
+    it("reverts invalid claim", async function () {
+      const proof = [makeElement(owner.address, "10")];
+      await expect(
+        contracts.beneficiaryVaults.claimReward(0, proof, owner.address, "10")
+      ).to.be.revertedWith("Invalid claim");
+    });
+
+    it("reverts claim when beneficiary does not exist", async function () {
+      const proof = merkleTree.getProof(
+        makeElement(beneficiary1.address, claims[beneficiary1.address])
+      );
+      await contracts.beneficiaryRegistry.mock.beneficiaryExists.returns(false);
+      await expect(
+        contracts.beneficiaryVaults
+          .connect(beneficiary1)
+          .claimReward(
+            0,
+            proof,
+            beneficiary1.address,
+            claims[beneficiary1.address]
+          )
+      ).to.be.revertedWith("Beneficiary does not exist");
+    });
+
+    it("verifies valid claim", async function () {
+      const proof = merkleTree.getProof(
+        makeElement(beneficiary1.address, claims[beneficiary1.address])
+      );
+      expect(
+        await contracts.beneficiaryVaults
+          .connect(beneficiary1)
+          .verifyClaim(
+            0,
+            proof,
+            beneficiary1.address,
+            claims[beneficiary1.address]
+          )
+      ).to.be.true;
+    });
+
+    describe("allocate rewards", function () {
+      it("allocates rewards", async function () {
         await contracts.mockPop
-          .connect(rewarder)
+          .connect(owner)
           .transfer(contracts.beneficiaryVaults.address, firstReward);
-        result = await contracts.beneficiaryVaults.allocateRewards();
-      });
-
-      it("contract has expected balance", async function () {
-        expect(
-          await contracts.mockPop.balanceOf(contracts.beneficiaryVaults.address)
-        ).to.equal(firstReward);
-      });
-
-      it("contract has expected vaulted balance", async function () {
+        await contracts.beneficiaryVaults.allocateRewards();
+        const vault = await contracts.beneficiaryVaults.getVault(0);
+        expect(vault.totalAllocated).to.equal(firstReward);
+        expect(vault.currentBalance).to.equal(firstReward);
         expect(
           await contracts.beneficiaryVaults.totalDistributedBalance()
         ).to.equal(firstReward);
       });
-
-      it("emits expected events", async function () {
-        expect(result)
-          .to.emit(contracts.beneficiaryVaults, "RewardsAllocated")
-          .withArgs(firstReward);
-      });
-
-      it("reverts invalid claim", async function () {
-        const proof = [makeElement(owner.address, "10")];
-        await expect(
-          contracts.beneficiaryVaults.claimReward(
-            0,
-
-            proof,
-            owner.address,
-            "10"
-          )
-        ).to.be.revertedWith("Invalid claim");
-      });
-
-      it("reverts claim when beneficiary does not exist", async function () {
-        const proof = merkleTree.getProof(
-          makeElement(beneficiary1.address, claims[beneficiary1.address])
-        );
-        await contracts.beneficiaryRegistry.mock.beneficiaryExists.returns(
-          false
-        );
-        await expect(
-          contracts.beneficiaryVaults.connect(beneficiary1).claimReward(
-            0,
-
-            proof,
-            beneficiary1.address,
-            claims[beneficiary1.address]
-          )
-        ).to.be.revertedWith("Beneficiary does not exist");
-      });
-
-      it("verifies valid claim", async function () {
-        const proof = merkleTree.getProof(
-          makeElement(beneficiary1.address, claims[beneficiary1.address])
-        );
-        expect(
-          await contracts.beneficiaryVaults.connect(beneficiary1).verifyClaim(
-            0,
-
-            proof,
-            beneficiary1.address,
-            claims[beneficiary1.address]
-          )
-        ).to.be.true;
-      });
-
-      it("reverts claim from wrong sender", async function () {
-        const proof = merkleTree.getProof(
-          makeElement(beneficiary1.address, claims[beneficiary1.address])
-        );
-        result = await expect(
-          contracts.beneficiaryVaults.connect(beneficiary2).claimReward(
-            0,
-
-            proof,
-            beneficiary1.address,
-            claims[beneficiary1.address]
-          )
-        ).to.be.revertedWith("Sender must be beneficiary");
-      });
-
-      it("reverts when reinitializing open vault", async function () {
-        await expect(
-          contracts.beneficiaryVaults.openVault(0, 0, merkleRoot)
-        ).to.be.revertedWith("Vault must not be open");
-      });
-
-      describe("allocate rewards", function () {
-        it("allocates rewards", async function () {
-          const vault = await contracts.beneficiaryVaults.getVault(0);
-          expect(vault.totalAllocated).to.equal(firstReward);
-          expect(vault.currentBalance).to.equal(firstReward);
-          expect(
-            await contracts.beneficiaryVaults.totalDistributedBalance()
-          ).to.equal(firstReward);
+      context("it reverts", function () {
+        it("when there are no funds to allocate", async function () {
+          await expect(
+            contracts.beneficiaryVaults.allocateRewards()
+          ).to.be.revertedWith("no rewards available");
         });
-        it("allocates rewards to multiple vaults evenly", async function () {
+        it("when a region as no open vaults", async function () {
+          await contracts.beneficiaryVaults.connect(owner).closeVault(0);
           await contracts.mockPop
             .connect(owner)
             .transfer(contracts.beneficiaryVaults.address, parseEther("1"));
-          await contracts.beneficiaryVaults.openVault(1, 1, merkleRoot);
-          await contracts.beneficiaryVaults.allocateRewards();
-          const vault0 = await contracts.beneficiaryVaults.getVault(0);
-          expect(vault0.totalAllocated).to.equal(
-            firstReward.add(parseEther("0.5"))
-          );
-          expect(vault0.currentBalance).to.equal(
-            firstReward.add(parseEther("0.5"))
-          );
-          const vault1 = await contracts.beneficiaryVaults.getVault(1);
-          expect(vault1.totalAllocated).to.equal(parseEther("0.5"));
-          expect(vault1.currentBalance).to.equal(parseEther("0.5"));
+          await expect(
+            contracts.beneficiaryVaults.allocateRewards()
+          ).to.be.revertedWith("no open vaults");
         });
-        context("it reverts", function () {
-          it("when there are no funds to allocate", async function () {
-            await expect(
-              contracts.beneficiaryVaults.allocateRewards()
-            ).to.be.revertedWith("no rewards available");
-          });
-          it("when a region as no open vaults", async function () {
-            await contracts.beneficiaryVaults.connect(owner).closeVault(0);
-            await contracts.mockPop
-              .connect(owner)
-              .transfer(contracts.beneficiaryVaults.address, parseEther("1"));
-            await expect(
-              contracts.beneficiaryVaults.allocateRewards()
-            ).to.be.revertedWith("no open vaults");
-          });
+      });
+
+      describe("claim from beneficiary 1", function () {
+        let beneficiary1Claim: BigNumber;
+        beforeEach(async function () {
+          await contracts.mockPop
+            .connect(owner)
+            .transfer(contracts.beneficiaryVaults.address, firstReward);
+          await contracts.beneficiaryVaults.allocateRewards();
+
+          beneficiary1Claim = firstReward
+            .mul(claims[beneficiary1.address])
+            .div(parseEther("100"));
+          const proof = merkleTree.getProof(
+            makeElement(beneficiary1.address, claims[beneficiary1.address])
+          );
+          result = await contracts.beneficiaryVaults
+            .connect(beneficiary1)
+            .claimReward(
+              0,
+              proof,
+              beneficiary1.address,
+              claims[beneficiary1.address]
+            );
         });
 
-        describe("claim from beneficiary 1", function () {
-          let beneficiary1Claim: BigNumber;
-          beforeEach(async function () {
-            beneficiary1Claim = firstReward
-              .mul(claims[beneficiary1.address])
-              .div(parseEther("100"));
-            const proof = merkleTree.getProof(
-              makeElement(beneficiary1.address, claims[beneficiary1.address])
-            );
-            result = await contracts.beneficiaryVaults
+        it("emits expected events", async function () {
+          expect(result)
+            .to.emit(contracts.beneficiaryVaults, "RewardClaimed")
+            .withArgs(0, beneficiary1.address, beneficiary1Claim);
+        });
+
+        it("contract has expected balance", async function () {
+          expect(
+            await contracts.mockPop.balanceOf(
+              contracts.beneficiaryVaults.address
+            )
+          ).to.equal(firstReward.sub(beneficiary1Claim));
+        });
+
+        it("contract has expected vaulted balance", async function () {
+          expect(
+            await contracts.beneficiaryVaults.totalDistributedBalance()
+          ).to.equal(firstReward.sub(beneficiary1Claim));
+        });
+
+        it("vault has expected data", async function () {
+          const currentBalance = firstReward.sub(beneficiary1Claim);
+          const unclaimedShare = parseEther("100").sub(
+            claims[beneficiary1.address]
+          );
+          const vaultData = await contracts.beneficiaryVaults.getVault(0);
+          expect(vaultData.totalAllocated).to.equal(firstReward);
+          expect(vaultData.currentBalance).to.equal(currentBalance);
+          expect(vaultData.unclaimedShare).to.equal(unclaimedShare);
+          expect(
+            await contracts.beneficiaryVaults.hasClaimed(
+              0,
+              beneficiary1.address
+            )
+          ).to.be.true;
+        });
+
+        it("reverts a second claim", async function () {
+          const proof = merkleTree.getProof(
+            makeElement(beneficiary1.address, claims[beneficiary1.address])
+          );
+          await expect(
+            contracts.beneficiaryVaults
               .connect(beneficiary1)
               .claimReward(
                 0,
-
                 proof,
                 beneficiary1.address,
                 claims[beneficiary1.address]
-              );
+              )
+          ).to.be.revertedWith("Already claimed");
+        });
+        describe("deposit more rewards and distribute", function () {
+          beforeEach(async function () {
+            await contracts.mockPop
+              .connect(rewarder)
+              .transfer(contracts.beneficiaryVaults.address, secondReward);
+            result = await contracts.beneficiaryVaults
+              .connect(rewarder)
+              .allocateRewards();
           });
 
-          it("emits expected events", async function () {
-            expect(result)
-              .to.emit(contracts.beneficiaryVaults, "RewardClaimed")
-              .withArgs(
-                0,
-
-                beneficiary1.address,
-                beneficiary1Claim
-              );
-          });
-
-          it("contract has expected balance", async function () {
+          it("has expected contract balance", async function () {
+            const currentBalance = firstReward
+              .sub(beneficiary1Claim)
+              .add(secondReward);
             expect(
               await contracts.mockPop.balanceOf(
                 contracts.beneficiaryVaults.address
               )
-            ).to.equal(firstReward.sub(beneficiary1Claim));
+            ).to.equal(currentBalance);
           });
 
           it("contract has expected vaulted balance", async function () {
+            const currentBalance = firstReward
+              .sub(beneficiary1Claim)
+              .add(secondReward);
             expect(
               await contracts.beneficiaryVaults.totalDistributedBalance()
-            ).to.equal(firstReward.sub(beneficiary1Claim));
+            ).to.equal(currentBalance);
           });
 
-          it("vault has expected data", async function () {
-            const currentBalance = firstReward.sub(beneficiary1Claim);
-            const unclaimedShare = parseEther("100").sub(
-              claims[beneficiary1.address]
-            );
-            const vaultData = await contracts.beneficiaryVaults.getVault(0);
-            expect(vaultData.totalAllocated).to.equal(firstReward);
-            expect(vaultData.currentBalance).to.equal(currentBalance);
-            expect(vaultData.unclaimedShare).to.equal(unclaimedShare);
-            expect(
-              await contracts.beneficiaryVaults.hasClaimed(
-                0,
-
-                beneficiary1.address
-              )
-            ).to.be.true;
+          it("emits expected events", async function () {
+            expect(result)
+              .to.emit(contracts.beneficiaryVaults, "RewardsAllocated")
+              .withArgs(secondReward);
           });
 
-          it("reverts a second claim", async function () {
-            const proof = merkleTree.getProof(
-              makeElement(beneficiary1.address, claims[beneficiary1.address])
-            );
-            await expect(
-              contracts.beneficiaryVaults.connect(beneficiary1).claimReward(
-                0,
-
-                proof,
-                beneficiary1.address,
-                claims[beneficiary1.address]
-              )
-            ).to.be.revertedWith("Already claimed");
-          });
-          describe("deposit more rewards and distribute", function () {
+          describe("claim from beneficiary 2", function () {
+            let beneficiary2Claim: BigNumber;
             beforeEach(async function () {
-              await contracts.mockPop
-                .connect(rewarder)
-                .transfer(contracts.beneficiaryVaults.address, secondReward);
+              beneficiary2Claim = firstReward
+                .add(secondReward)
+                .sub(beneficiary1Claim)
+                .mul(claims[beneficiary2.address])
+                .div(parseEther("100").sub(claims[beneficiary1.address]));
+
+              const proof = merkleTree.getProof(
+                makeElement(beneficiary2.address, claims[beneficiary2.address])
+              );
+
               result = await contracts.beneficiaryVaults
-                .connect(rewarder)
-                .allocateRewards();
+                .connect(beneficiary2)
+                .claimReward(
+                  0,
+                  proof,
+                  beneficiary2.address,
+                  claims[beneficiary2.address]
+                );
+            });
+
+            it("emits expected events", async function () {
+              expect(result)
+                .to.emit(contracts.beneficiaryVaults, "RewardClaimed")
+                .withArgs(0, beneficiary2.address, beneficiary2Claim);
+            });
+
+            it("vault has expected data", async function () {
+              const currentBalance = firstReward
+                .add(secondReward)
+                .sub(beneficiary1Claim)
+                .sub(beneficiary2Claim);
+              const unclaimedShare = parseEther("100")
+                .sub(claims[beneficiary1.address])
+                .sub(claims[beneficiary2.address]);
+              const vaultData = await contracts.beneficiaryVaults.getVault(0);
+              expect(vaultData.totalAllocated).to.equal(
+                firstReward.add(secondReward)
+              );
+              expect(vaultData.currentBalance).to.equal(currentBalance);
+              expect(vaultData.unclaimedShare).to.equal(unclaimedShare);
+              expect(
+                await contracts.beneficiaryVaults.hasClaimed(
+                  0,
+                  beneficiary2.address
+                )
+              ).to.be.true;
             });
 
             it("has expected contract balance", async function () {
               const currentBalance = firstReward
+                .add(secondReward)
                 .sub(beneficiary1Claim)
-                .add(secondReward);
+                .sub(beneficiary2Claim);
               expect(
                 await contracts.mockPop.balanceOf(
                   contracts.beneficiaryVaults.address
@@ -437,199 +423,81 @@ describe("BeneficiaryVaults", function () {
             it("contract has expected vaulted balance", async function () {
               const currentBalance = firstReward
                 .sub(beneficiary1Claim)
-                .add(secondReward);
+                .add(secondReward)
+                .sub(beneficiary2Claim);
               expect(
                 await contracts.beneficiaryVaults.totalDistributedBalance()
               ).to.equal(currentBalance);
             });
+          });
 
-            it("emits expected events", async function () {
+          describe("closes vault 0", function () {
+            beforeEach(async function () {
+              result = await contracts.beneficiaryVaults.closeVault(0);
+            });
+
+            it("emits a VaultClosed event", async function () {
               expect(result)
-                .to.emit(contracts.beneficiaryVaults, "RewardsAllocated")
-                .withArgs(secondReward);
+                .to.emit(contracts.beneficiaryVaults, "VaultClosed")
+                .withArgs(0);
             });
 
-            describe("claim from beneficiary 2", function () {
-              let beneficiary2Claim: BigNumber;
-              beforeEach(async function () {
-                beneficiary2Claim = firstReward
-                  .add(secondReward)
-                  .sub(beneficiary1Claim)
-                  .mul(claims[beneficiary2.address])
-                  .div(parseEther("100").sub(claims[beneficiary1.address]));
-
-                const proof = merkleTree.getProof(
-                  makeElement(
-                    beneficiary2.address,
-                    claims[beneficiary2.address]
-                  )
-                );
-
-                result = await contracts.beneficiaryVaults
-                  .connect(beneficiary2)
-                  .claimReward(
-                    0,
-
-                    proof,
-                    beneficiary2.address,
-                    claims[beneficiary2.address]
-                  );
-              });
-
-              it("emits expected events", async function () {
-                expect(result)
-                  .to.emit(contracts.beneficiaryVaults, "RewardClaimed")
-                  .withArgs(
-                    0,
-
-                    beneficiary2.address,
-                    beneficiary2Claim
-                  );
-              });
-
-              it("vault has expected data", async function () {
-                const currentBalance = firstReward
-                  .add(secondReward)
-                  .sub(beneficiary1Claim)
-                  .sub(beneficiary2Claim);
-                const unclaimedShare = parseEther("100")
-                  .sub(claims[beneficiary1.address])
-                  .sub(claims[beneficiary2.address]);
-                const vaultData = await contracts.beneficiaryVaults.getVault(0);
-                expect(vaultData.totalAllocated).to.equal(
-                  firstReward.add(secondReward)
-                );
-                expect(vaultData.currentBalance).to.equal(currentBalance);
-                expect(vaultData.unclaimedShare).to.equal(unclaimedShare);
-                expect(
-                  await contracts.beneficiaryVaults.hasClaimed(
-                    0,
-
-                    beneficiary2.address
-                  )
-                ).to.be.true;
-              });
-
-              it("has expected contract balance", async function () {
-                const currentBalance = firstReward
-                  .add(secondReward)
-                  .sub(beneficiary1Claim)
-                  .sub(beneficiary2Claim);
-                expect(
-                  await contracts.mockPop.balanceOf(
-                    contracts.beneficiaryVaults.address
-                  )
-                ).to.equal(currentBalance);
-              });
-
-              it("contract has expected vaulted balance", async function () {
-                const currentBalance = firstReward
-                  .sub(beneficiary1Claim)
-                  .add(secondReward)
-                  .sub(beneficiary2Claim);
-                expect(
-                  await contracts.beneficiaryVaults.totalDistributedBalance()
-                ).to.equal(currentBalance);
-              });
+            it("has expected contract balance", async function () {
+              expect(
+                await contracts.mockPop.balanceOf(
+                  contracts.beneficiaryVaults.address
+                )
+              ).to.equal(firstReward.add(secondReward).sub(beneficiary1Claim));
             });
 
-            describe("closes vault 0", function () {
-              beforeEach(async function () {
-                result = await contracts.beneficiaryVaults.closeVault(0);
-              });
-
-              it("emits a VaultClosed event", async function () {
-                expect(result)
-                  .to.emit(contracts.beneficiaryVaults, "VaultClosed")
-                  .withArgs(0);
-              });
-
-              it("has expected contract balance", async function () {
-                expect(
-                  await contracts.mockPop.balanceOf(
-                    contracts.beneficiaryVaults.address
-                  )
-                ).to.equal(
-                  firstReward.add(secondReward).sub(beneficiary1Claim)
-                );
-              });
-
-              it("vault has expected data", async function () {
-                const vaultData = await contracts.beneficiaryVaults.getVault(0);
-                expect(vaultData.totalAllocated).to.equal(
-                  firstReward.add(secondReward)
-                );
-                expect(vaultData.currentBalance).to.equal(0);
-              });
+            it("vault has expected data", async function () {
+              const vaultData = await contracts.beneficiaryVaults.getVault(0);
+              expect(vaultData.totalAllocated).to.equal(
+                firstReward.add(secondReward)
+              );
+              expect(vaultData.currentBalance).to.equal(0);
             });
-            describe("open vault 1", function () {
-              beforeEach(async function () {
-                await contracts.beneficiaryVaults.openVault(1, 1, merkleRoot);
-              });
+          });
+          describe("open vault 1", function () {
+            beforeEach(async function () {
+              await contracts.beneficiaryVaults.openVault(1, 1, merkleRoot);
+            });
 
-              it("vault 1 has expected values", async function () {
-                const vaultData = await contracts.beneficiaryVaults.getVault(1);
-                expect(vaultData.totalAllocated).to.equal(0);
-                expect(vaultData.currentBalance).to.equal(0);
-                expect(vaultData.unclaimedShare).to.equal(parseEther("100"));
-                expect(vaultData.merkleRoot).to.equal(merkleRoot);
-                expect(vaultData.status).to.equal(VaultStatus.Open);
-                expect(
-                  await contracts.beneficiaryVaults.hasClaimed(
-                    1,
-
-                    beneficiary1.address
-                  )
-                ).to.be.false;
-                expect(
-                  await contracts.beneficiaryVaults.hasClaimed(
-                    1,
-
-                    beneficiary2.address
-                  )
-                ).to.be.false;
-              });
-
-              describe("close vault 0 and redirect remaining rewards to vault 1", function () {
-                beforeEach(async function () {
-                  await contracts.beneficiaryVaults.closeVault(0);
-                });
-
-                it("contract has expected vaulted balance", async function () {
-                  const currentBalance = firstReward
-                    .add(secondReward)
-                    .sub(beneficiary1Claim);
-                  expect(
-                    await contracts.beneficiaryVaults.totalDistributedBalance()
-                  ).to.equal(currentBalance);
-                });
-
-                it("vault 1 has expected values", async function () {
-                  const currentBalance = firstReward
-                    .add(secondReward)
-                    .sub(beneficiary1Claim);
-                  const vaultData = await contracts.beneficiaryVaults.getVault(
-                    1
-                  );
-                  expect(vaultData.totalAllocated).to.equal(currentBalance);
-                  expect(vaultData.currentBalance).to.equal(currentBalance);
-                  expect(vaultData.unclaimedShare).to.equal(parseEther("100"));
-                  expect(
-                    await contracts.beneficiaryVaults.hasClaimed(
-                      1,
-
-                      beneficiary1.address
-                    )
-                  ).to.be.false;
-                  expect(
-                    await contracts.beneficiaryVaults.hasClaimed(
-                      1,
-
-                      beneficiary2.address
-                    )
-                  ).to.be.false;
-                });
-              });
+            it("vault 1 has expected values", async function () {
+              const vaultData = await contracts.beneficiaryVaults.getVault(1);
+              expect(vaultData.totalAllocated).to.equal(0);
+              expect(vaultData.currentBalance).to.equal(0);
+              expect(vaultData.unclaimedShare).to.equal(parseEther("100"));
+              expect(vaultData.merkleRoot).to.equal(merkleRoot);
+              expect(vaultData.status).to.equal(VaultStatus.Open);
+              expect(
+                await contracts.beneficiaryVaults.hasClaimed(
+                  1,
+                  beneficiary1.address
+                )
+              ).to.be.false;
+              expect(
+                await contracts.beneficiaryVaults.hasClaimed(
+                  1,
+                  beneficiary2.address
+                )
+              ).to.be.false;
+            });
+            it("allocates rewards to multiple vaults evenly", async function () {
+              await contracts.mockPop
+                .connect(owner)
+                .transfer(contracts.beneficiaryVaults.address, parseEther("1"));
+              await contracts.beneficiaryVaults.allocateRewards();
+              const vault0 = await contracts.beneficiaryVaults.getVault(0);
+              expect(vault0.totalAllocated).to.equal(
+                firstReward.add(parseEther("0.5"))
+              );
+              expect(vault0.currentBalance).to.equal(
+                firstReward.add(parseEther("0.5"))
+              );
+              const vault1 = await contracts.beneficiaryVaults.getVault(1);
+              expect(vault1.totalAllocated).to.equal(parseEther("0.5"));
+              expect(vault1.currentBalance).to.equal(parseEther("0.5"));
             });
           });
         });

--- a/packages/contracts/test/GrantElections.test.ts
+++ b/packages/contracts/test/GrantElections.test.ts
@@ -689,7 +689,7 @@ describe("GrantElections", function () {
 
       await expect(result)
         .to.emit(contracts.beneficiaryVaults, "VaultClosed")
-        .withArgs(GRANT_TERM.QUARTER);
+        .withArgs(electionId);
 
       const activeElectionId = await contracts.grantElections.activeElections(
         DEFAULT_REGION,
@@ -1034,7 +1034,7 @@ describe("GrantElections", function () {
             .withArgs(electionId, merkleRoot);
           expect(result)
             .to.emit(contracts.beneficiaryVaults, "VaultOpened")
-            .withArgs(0, merkleRoot);
+            .withArgs(electionId, GRANT_TERM.MONTH, merkleRoot);
           const election = await contracts.grantElections.elections(electionId);
           expect(election.electionState).to.equal(4);
         });


### PR DESCRIPTION
Beneficiary Vaults can now always get claimed as long as the beneficiary still has shares.
Vaults are saved by electionId so each election has a corresponding vault.
ActiveVaults is an array of the ids of active vaults (receiving rewards) by election term. 

notice: Since the activeVaults array is initialized with 0 in each slot but 0 can be a valid vault id i added some checks to make sure that the vault is really the active vault for this term and not just not initialized yet. 
notice: While election ids are continuous numbers they might be held in different regions which makes it necessary to use a mapping to save vaults instead of an array.