### PR TITLE
fix responsive sizing issues

### DIFF
--- a/packages/app/pages/index.tsx
+++ b/packages/app/pages/index.tsx
@@ -187,7 +187,7 @@ const IndexPage = () => {
             </div>
           </nav>
         </header>
-        <section className="max-h-screen min-h-full">
+        <section className="min-h-full">
           <div className="bg-primary w-full h-8 2xl:h-28"></div>
           <div
             className="bg-hero-pattern flex-shrink-0 flex-grow-0 w-full h-full"
@@ -664,7 +664,7 @@ const IndexPage = () => {
             <Menu onClick={(e) => toggleMenu(true)} />
           </nav>
         </header>
-        <section className="max-h-screen min-h-full">
+        <section className="min-h-full">
           <div className="bg-primary w-full h-12"></div>
           <div
             className="bg-hero-pattern flex-shrink-0 flex-grow-0 w-full h-full pt-6 md:pt-10"


### PR DESCRIPTION
Landing page first section is allowed to be larger than one screen size to allow for small screen sizes on mobile & desktop