### PR TITLE
Standalone keeper incentives and participation reward

### DIFF
--- a/packages/contracts/contracts/GrantElections.sol
+++ b/packages/contracts/contracts/GrantElections.sol
@@ -11,7 +11,7 @@ import "./Interfaces/IRegion.sol";
 import "./Governed.sol";
 import "./ParticipationReward.sol";
 
-contract GrantElections is ParticipationReward {
+contract GrantElections is Governed {
   using SafeMath for uint256;
   using SafeERC20 for IERC20;
 
@@ -74,10 +74,14 @@ contract GrantElections is ParticipationReward {
 
   /* ========== STATE VARIABLES ========== */
 
+  IERC20 internal POP;
   IRegion internal region;
   IStaking internal staking;
   IBeneficiaryRegistry internal beneficiaryRegistry;
   IRandomNumberConsumer internal randomNumberConsumer;
+  ParticipationReward internal participationReward;
+
+  bytes32 public immutable contractName = "GrantElections";
 
   Election[] public elections;
   mapping(bytes2 => uint256[3]) public activeElections;
@@ -111,12 +115,15 @@ contract GrantElections is ParticipationReward {
     IRandomNumberConsumer _randomNumberConsumer,
     IERC20 _pop,
     IRegion _region,
+    ParticipationReward _participationReward,
     address _governance
-  ) ParticipationReward(_pop, _governance) {
+  ) Governed(_governance) {
     staking = _staking;
     beneficiaryRegistry = _beneficiaryRegistry;
     randomNumberConsumer = _randomNumberConsumer;
     region = _region;
+    POP = _pop;
+    participationReward = _participationReward;
     _setDefaults();
   }
 
@@ -233,7 +240,8 @@ contract GrantElections is ParticipationReward {
     election.electionTerm = _grantTerm;
     election.startTime = block.timestamp;
     election.region = _region;
-    (bool vaultCreated, bytes32 vaultId) = _initializeVault(
+    (bool vaultCreated, bytes32 vaultId) = participationReward.initializeVault(
+      contractName,
       keccak256(abi.encodePacked(_term, block.timestamp)),
       block.timestamp.add(electionDefaults[_term].registrationPeriod).add(
         electionDefaults[_term].votingPeriod
@@ -361,7 +369,12 @@ contract GrantElections is ParticipationReward {
       "Insufficient voice credits"
     );
     if (election.vaultId != "") {
-      _addShares(election.vaultId, msg.sender, _usedVoiceCredits);
+      participationReward.addShares(
+        contractName,
+        election.vaultId,
+        msg.sender,
+        _usedVoiceCredits
+      );
     }
     emit UserVoted(msg.sender, election.electionTerm);
   }
@@ -447,7 +460,7 @@ contract GrantElections is ParticipationReward {
       uint8(election.electionTerm),
       _merkleRoot
     );
-    _openVault(election.vaultId);
+    participationReward.openVault(contractName, election.vaultId);
     election.electionState = ElectionState.Finalized;
 
     emit ElectionFinalized(_electionId, _merkleRoot);

--- a/packages/contracts/contracts/HysiBatchInteraction.sol
+++ b/packages/contracts/contracts/HysiBatchInteraction.sol
@@ -22,7 +22,7 @@ The HYSI is created from 4 different yToken which in turn need each a deposit of
 This means 12 approvals and 9 deposits are necessary to mint one HYSI.
 We Batch this process and allow users to pool their funds. Than we pay keeper to Mint or Redeem HYSI regularly.
 */
-contract HysiBatchInteraction is Owned, KeeperIncentive {
+contract HysiBatchInteraction is Owned {
   using SafeMath for uint256;
   using SafeERC20 for YearnVault;
   using SafeERC20 for ISetToken;
@@ -70,8 +70,12 @@ contract HysiBatchInteraction is Owned, KeeperIncentive {
 
   /* ========== STATE VARIABLES ========== */
 
+  bytes32 public immutable contractName = "HysiBatchInteraction";
+
+  IERC20 public POP;
   IERC20 public threeCrv;
   BasicIssuanceModule public setBasicIssuanceModule;
+  KeeperIncentive public keeperIncentive;
   ISetToken public setToken;
   address public zapper;
   mapping(address => CurvePoolTokenPair) public curvePoolTokenPairs;
@@ -123,23 +127,27 @@ contract HysiBatchInteraction is Owned, KeeperIncentive {
   /* ========== CONSTRUCTOR ========== */
 
   constructor(
+    IERC20 pop_,
     IERC20 threeCrv_,
     ISetToken setToken_,
     BasicIssuanceModule basicIssuanceModule_,
+    KeeperIncentive keeperIncentive_,
     address[] memory yTokenAddresses_,
     CurvePoolTokenPair[] memory curvePoolTokenPairs_,
     uint256 batchCooldown_,
     uint256 mintThreshold_,
-    uint256 redeemThreshold_,
-    address governance_,
-    IERC20 pop_
-  ) Owned(msg.sender) KeeperIncentive(governance_, pop_) {
+    uint256 redeemThreshold_
+  ) Owned(msg.sender) {
+    require(address(pop_) != address(0));
     require(address(threeCrv_) != address(0));
     require(address(setToken_) != address(0));
     require(address(basicIssuanceModule_) != address(0));
+    require(address(basicIssuanceModule_) != address(0));
+    POP = pop_;
     threeCrv = threeCrv_;
     setToken = setToken_;
     setBasicIssuanceModule = basicIssuanceModule_;
+    keeperIncentive = keeperIncentive_;
 
     _setCurvePoolTokenPairs(yTokenAddresses_, curvePoolTokenPairs_);
 
@@ -345,9 +353,10 @@ contract HysiBatchInteraction is Owned, KeeperIncentive {
    * @dev This function deposits 3CRV in the underlying Metapool and deposits these LP token to get yToken which in turn are used to mint HYSI
    * @dev This process leaves some leftovers which are partially used in the next mint batches.
    * @dev In order to get 3CRV we can implement a zap to move stables into the curve tri-pool
-   * @dev keeperIncentive(0) checks if the msg.sender is a permissioned keeper and pays them a reward for calling this function (see KeeperIncentive.sol)
+   * @dev handleKeeperIncentive checks if the msg.sender is a permissioned keeper and pays them a reward for calling this function (see KeeperIncentive.sol)
    */
-  function batchMint(uint256 minAmountToMint_) external keeperIncentive(0) {
+  function batchMint(uint256 minAmountToMint_) external {
+    keeperIncentive.handleKeeperIncentive(contractName, msg.sender);
     Batch storage batch = batches[currentMintBatchId];
 
     //Check if there was enough time between the last batch minting and this attempt...
@@ -487,9 +496,10 @@ contract HysiBatchInteraction is Owned, KeeperIncentive {
    * @param min3crvToReceive_ sets minimum amount of 3crv to redeem HYSI for, otherwise the transaction will revert
    * @dev This function reedeems HYSI for the underlying yToken and deposits these yToken in curve Metapools for 3CRV
    * @dev In order to get stablecoins from 3CRV we can use a zap to redeem 3CRV for stables in the curve tri-pool
-   * @dev keeperIncentive(0) checks if the msg.sender is a permissioned keeper and pays them a reward for calling this function (see KeeperIncentive.sol)
+   * @dev handleKeeperIncentive checks if the msg.sender is a permissioned keeper and pays them a reward for calling this function (see KeeperIncentive.sol)
    */
-  function batchRedeem(uint256 min3crvToReceive_) external keeperIncentive(0) {
+  function batchRedeem(uint256 min3crvToReceive_) external {
+    keeperIncentive.handleKeeperIncentive(contractName, msg.sender);
     Batch storage batch = batches[currentRedeemBatchId];
 
     //Check if there was enough time between the last batch redemption and this attempt...

--- a/packages/contracts/contracts/KeeperIncentive.sol
+++ b/packages/contracts/contracts/KeeperIncentive.sol
@@ -17,89 +17,137 @@ contract KeeperIncentive is Governed {
   /* ========== STATE VARIABLES ========== */
 
   IERC20 public immutable POP;
-  Incentive[] public incentives;
   uint256 public incentiveBudget;
-  mapping(address => bool) public approved;
+  mapping(bytes32 => Incentive) public incentives;
+  mapping(bytes32 => mapping(address => bool)) public approved;
+  mapping(bytes32 => address) public controllerContracts;
 
   /* ========== EVENTS ========== */
 
-  event IncentiveCreated(uint256 incentiveId);
-  event IncentiveChanged(uint256 incentiveId);
+  event IncentiveCreated(
+    bytes32 contractName,
+    uint256 reward,
+    bool openToEveryone
+  );
+  event IncentiveChanged(
+    bytes32 contractName,
+    uint256 oldReward,
+    uint256 newReward,
+    bool oldOpenToEveryone,
+    bool newOpenToEveryone
+  );
   event IncentiveFunded(uint256 amount);
-  event Approved(address account);
-  event RemovedApproval(address account);
-  event ApprovalToggled(uint256 incentiveId, bool openToEveryone);
-  event IncentiveToggled(uint256 incentiveId, bool enabled);
+  event Approved(bytes32 contractName, address account);
+  event RemovedApproval(bytes32 contractName, address account);
+  event ApprovalToggled(bytes32 contractName, bool openToEveryone);
+  event IncentiveToggled(bytes32 contractName, bool enabled);
+  event ControllerContractAdded(bytes32 contractName, address contractAddress);
 
   /* ========== CONSTRUCTOR ========== */
 
-  constructor(address _governance, IERC20 _pop) public Governed(_governance) {
+  constructor(IERC20 _pop, address _governance) public Governed(_governance) {
     POP = _pop;
-    createIncentive(10e18, true, false);
+  }
+
+  /* ==========  MUTATIVE FUNCTIONS  ========== */
+
+  function handleKeeperIncentive(bytes32 contractName_, address keeper)
+    external
+  {
+    require(
+      msg.sender == controllerContracts[contractName_],
+      "Can only be called by the controlling contract"
+    );
+
+    Incentive memory incentive = incentives[contractName_];
+
+    if (!incentive.openToEveryone) {
+      require(
+        approved[contractName_][keeper],
+        "you are not approved as a keeper"
+      );
+    }
+    if (incentive.enabled && incentive.reward <= incentiveBudget) {
+      incentiveBudget = incentiveBudget.sub(incentive.reward);
+      POP.approve(address(this), incentive.reward);
+      POP.safeTransferFrom(address(this), msg.sender, incentive.reward);
+    }
   }
 
   /* ========== SETTER ========== */
 
   /**
    * @notice Create Incentives for keeper to call a function
+   * @param contractName_ Name of contract that uses ParticipationRewards in bytes32
    * @param _reward The amount in POP the Keeper receives for calling the function
    * @param _enabled Is this Incentive currently enabled?
    * @param _openToEveryone Can anyone call the function for rewards or only keeper?
    * @dev This function is only for creating unique incentives for future contracts
    * @dev Multiple functions can use the same incentive which can than be updated with one governance vote
-   * @dev Per default there will be always one incentive on index 0
    */
   function createIncentive(
+    bytes32 contractName_,
     uint256 _reward,
     bool _enabled,
     bool _openToEveryone
-  ) public onlyGovernance returns (uint256) {
-    incentives.push(
-      Incentive({
-        reward: _reward,
-        enabled: _enabled,
-        openToEveryone: _openToEveryone
-      })
-    );
-    emit IncentiveCreated(incentives.length);
-    return incentives.length;
+  ) public onlyGovernance {
+    incentives[contractName_] = Incentive({
+      reward: _reward,
+      enabled: _enabled,
+      openToEveryone: _openToEveryone
+    });
+    emit IncentiveCreated(contractName_, _reward, _openToEveryone);
   }
 
   /* ========== RESTRICTED FUNCTIONS ========== */
 
   function updateIncentive(
-    uint256 _incentiveId,
+    bytes32 contractName_,
     uint256 _reward,
     bool _enabled,
     bool _openToEveryone
   ) external onlyGovernance {
-    incentives[_incentiveId] = Incentive({
-      reward: _reward,
-      enabled: _enabled,
-      openToEveryone: _openToEveryone
-    });
-    emit IncentiveChanged(_incentiveId);
+    Incentive storage incentive = incentives[contractName_];
+    uint256 oldReward = incentive.reward;
+    bool oldOpenToEveryone = incentive.openToEveryone;
+    incentive.reward = _reward;
+    incentive.enabled = _enabled;
+    incentive.openToEveryone = _openToEveryone;
+    emit IncentiveChanged(
+      contractName_,
+      oldReward,
+      _reward,
+      oldOpenToEveryone,
+      _openToEveryone
+    );
   }
 
-  function approveAccount(address _account) external onlyGovernance {
-    approved[_account] = true;
-    emit Approved(_account);
+  function approveAccount(bytes32 contractName_, address _account)
+    external
+    onlyGovernance
+  {
+    approved[contractName_][_account] = true;
+    emit Approved(contractName_, _account);
   }
 
-  function removeApproval(address _account) external onlyGovernance {
-    approved[_account] = false;
-    emit RemovedApproval(_account);
+  function removeApproval(bytes32 contractName_, address _account)
+    external
+    onlyGovernance
+  {
+    approved[contractName_][_account] = false;
+    emit RemovedApproval(contractName_, _account);
   }
 
-  function toggleApproval(uint256 _incentiveId) external onlyGovernance {
-    incentives[_incentiveId].openToEveryone = !incentives[_incentiveId]
-      .openToEveryone;
-    emit ApprovalToggled(_incentiveId, incentives[_incentiveId].openToEveryone);
+  function toggleApproval(bytes32 contractName_) external onlyGovernance {
+    Incentive storage incentive = incentives[contractName_];
+    incentive.openToEveryone = !incentive.openToEveryone;
+    emit ApprovalToggled(contractName_, incentive.openToEveryone);
   }
 
-  function toggleIncentive(uint256 _incentiveId) external onlyGovernance {
-    incentives[_incentiveId].enabled = !incentives[_incentiveId].enabled;
-    emit IncentiveToggled(_incentiveId, incentives[_incentiveId].enabled);
+  function toggleIncentive(bytes32 contractName_) external onlyGovernance {
+    Incentive storage incentive = incentives[contractName_];
+    incentive.enabled = !incentive.enabled;
+    emit IncentiveToggled(contractName_, incentive.enabled);
   }
 
   function fundIncentive(uint256 _amount) external {
@@ -108,24 +156,17 @@ contract KeeperIncentive is Governed {
     emit IncentiveFunded(_amount);
   }
 
-  /* ========== MODIFIER ========== */
-
-  modifier keeperIncentive(uint256 _incentiveId) {
-    if (_incentiveId < incentives.length) {
-      Incentive storage incentive = incentives[_incentiveId];
-
-      if (!incentive.openToEveryone) {
-        require(
-          approved[msg.sender] || msg.sender == governance,
-          "you are not approved as a keeper"
-        );
-      }
-      if (incentive.enabled && incentive.reward <= incentiveBudget) {
-        incentiveBudget = incentiveBudget.sub(incentive.reward);
-        POP.approve(address(this), incentive.reward);
-        POP.safeTransferFrom(address(this), msg.sender, incentive.reward);
-      }
-    }
-    _;
+  /**
+   * @notice In order to allow a contract to use ParticipationReward they need to be added as a controller contract
+   * @param contractName_ the name of the controller contract in bytes32
+   * @param contract_ the address of the controller contract
+   * @dev all critical functions to init/open vaults and add shares to them can only be called by controller contracts
+   */
+  function addControllerContract(bytes32 contractName_, address contract_)
+    external
+    onlyGovernance
+  {
+    controllerContracts[contractName_] = contract_;
+    emit ControllerContractAdded(contractName_, contract_);
   }
 }

--- a/packages/contracts/contracts/RewardsManager.sol
+++ b/packages/contracts/contracts/RewardsManager.sol
@@ -21,12 +21,7 @@ import "./Interfaces/IRewardsManager.sol";
  * @title Popcorn Rewards Manager
  * @notice Manages distribution of POP rewards to Popcorn Treasury, DAO Staking, and Beneficiaries
  */
-contract RewardsManager is
-  IRewardsManager,
-  Owned,
-  ReentrancyGuard,
-  KeeperIncentive
-{
+contract RewardsManager is IRewardsManager, Owned, ReentrancyGuard {
   using SafeMath for uint256;
   using SafeERC20 for IERC20;
 
@@ -40,11 +35,14 @@ contract RewardsManager is
   /* ========== STATE VARIABLES ========== */
 
   uint256 public constant SWAP_TIMEOUT = 600;
+  bytes32 public immutable contractName = "RewardsManager";
 
+  IERC20 public POP;
   IStaking public staking;
   ITreasury public treasury;
   IInsurance public insurance;
   IRegion public region;
+  KeeperIncentive public keeperIncentive;
   IUniswapV2Router02 public immutable uniswapV2Router;
 
   uint256[4] public rewardSplits;
@@ -72,12 +70,15 @@ contract RewardsManager is
     ITreasury treasury_,
     IInsurance insurance_,
     IRegion region_,
+    KeeperIncentive keeperIncentive_,
     IUniswapV2Router02 uniswapV2Router_
-  ) Owned(msg.sender) KeeperIncentive(msg.sender, pop_) {
+  ) Owned(msg.sender) {
+    POP = pop_;
     staking = staking_;
     treasury = treasury_;
     insurance = insurance_;
     region = region_;
+    keeperIncentive = keeperIncentive_;
     uniswapV2Router = uniswapV2Router_;
     rewardLimits[uint8(RewardTargets.Staking)] = [20e18, 80e18];
     rewardLimits[uint8(RewardTargets.Treasury)] = [10e18, 80e18];
@@ -106,9 +107,9 @@ contract RewardsManager is
   function swapTokenForRewards(address[] calldata path_, uint256 minAmountOut_)
     public
     nonReentrant
-    keeperIncentive(0)
     returns (uint256[] memory)
   {
+    keeperIncentive.handleKeeperIncentive(contractName, msg.sender);
     require(path_.length >= 2, "Invalid swap path");
     require(minAmountOut_ > 0, "Invalid amount");
     require(
@@ -137,7 +138,8 @@ contract RewardsManager is
    * @notice Distribute POP rewards to dependent RewardTarget contracts
    * @dev Contract must have POP balance in order to distribute according to rewardSplits ratio
    */
-  function distributeRewards() public nonReentrant keeperIncentive(0) {
+  function distributeRewards() public nonReentrant {
+    keeperIncentive.handleKeeperIncentive(contractName, msg.sender);
     uint256 _availableReward = POP.balanceOf(address(this));
     require(_availableReward > 0, "No POP balance");
 

--- a/packages/contracts/contracts/test_helpers/KeeperIncentiveHelper.sol
+++ b/packages/contracts/contracts/test_helpers/KeeperIncentiveHelper.sol
@@ -6,19 +6,21 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 
 import "../KeeperIncentive.sol";
 
-contract KeeperIncentiveHelper is KeeperIncentive {
+contract KeeperIncentiveHelper {
   using SafeERC20 for IERC20;
   using SafeMath for uint256;
 
+  KeeperIncentive public keeperIncentive;
+  bytes32 public immutable contractName = "KeeperIncentiveHelper";
+
   event FunctionCalled(address account);
 
-  constructor(IERC20 pop_) public KeeperIncentive(msg.sender, pop_) {}
-
-  function defaultIncentivisedFunction() public keeperIncentive(0) {
-    emit FunctionCalled(msg.sender);
+  constructor(KeeperIncentive keeperIncentive_) public {
+    keeperIncentive = keeperIncentive_;
   }
 
-  function incentivisedFunction() public keeperIncentive(1) {
+  function incentivisedFunction() public {
+    keeperIncentive.handleKeeperIncentive(contractName, msg.sender);
     emit FunctionCalled(msg.sender);
   }
 }

--- a/packages/contracts/contracts/test_helpers/ParticipationRewardHelper.sol
+++ b/packages/contracts/contracts/test_helpers/ParticipationRewardHelper.sol
@@ -6,20 +6,23 @@ import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 import "../ParticipationReward.sol";
 
-contract ParticipationRewardHelper is ParticipationReward {
+contract ParticipationRewardHelper {
   using SafeMath for uint256;
   using SafeERC20 for IERC20;
 
-  constructor(IERC20 _pop, address _governance)
-    ParticipationReward(_pop, _governance)
-  {}
+  ParticipationReward public participationReward;
+  bytes32 public immutable contractName = "ParticipationRewardHelper";
+
+  constructor(ParticipationReward _participationReward) {
+    participationReward = _participationReward;
+  }
 
   function initializeVault(bytes32 vaultId_, uint256 endTime_) external {
-    _initializeVault(vaultId_, endTime_);
+    participationReward.initializeVault(contractName, vaultId_, endTime_);
   }
 
   function openVault(bytes32 vaultId_) external {
-    _openVault(vaultId_);
+    participationReward.openVault(contractName, vaultId_);
   }
 
   function addShares(
@@ -27,6 +30,6 @@ contract ParticipationRewardHelper is ParticipationReward {
     address account_,
     uint256 shares_
   ) external {
-    _addShares(vaultId_, account_, shares_);
+    participationReward.addShares(contractName, vaultId_, account_, shares_);
   }
 }


### PR DESCRIPTION
KeeperIncentive and ParticipationReward are now deployed standalone.
Contracts that need to use KeeperIncentive/ParticipationReward can use them as external contracts.