### PR TITLE
Feature/restrict proposals by type

### DIFF
--- a/packages/app/components/Proposals/ProposalPage.tsx
+++ b/packages/app/components/Proposals/ProposalPage.tsx
@@ -16,6 +16,7 @@ import NavBar from 'components/NavBar/NavBar';
 import { ContractsContext } from 'context/Web3/contracts';
 import { useRouter } from 'next/router';
 import React, { useContext, useEffect, useState } from 'react';
+import toast, { Toaster } from 'react-hot-toast';
 import Voting from './Voting/Voting';
 
 const getTitle = (proposal: Proposal): string => {
@@ -48,12 +49,8 @@ const ProposalPage: React.FC<ProposalPageProps> = ({ proposalType }) => {
         IpfsClient,
       )
         .getProposal(Number(proposalId), proposalType)
-        .then((res) => {
-          setProposal(res);
-        })
-        .catch((err) => {
-          console.log(err);
-        });
+        .then((res) => setProposal(res))
+        .catch((err) => toast.error(err.message));
     }
   }, [contracts, account, proposalId]);
 
@@ -94,6 +91,7 @@ const ProposalPage: React.FC<ProposalPageProps> = ({ proposalType }) => {
   return (
     <div className="flex flex-col h-full w-full pb-16 ">
       <NavBar />
+      <Toaster position="top-right" />
       {getContent()}
     </div>
   );

--- a/packages/app/components/Proposals/ProposalPage.tsx
+++ b/packages/app/components/Proposals/ProposalPage.tsx
@@ -3,6 +3,7 @@ import {
   BeneficiaryGovernanceAdapter,
   Proposal,
   ProposalStatus,
+  ProposalType,
 } from '@popcorn/contracts/adapters';
 import { IpfsClient } from '@popcorn/utils';
 import { useWeb3React } from '@web3-react/core';
@@ -23,7 +24,11 @@ const getTitle = (proposal: Proposal): string => {
   }`;
 };
 
-const ProposalPage: React.FC = () => {
+export interface ProposalPageProps {
+  proposalType: ProposalType;
+}
+
+const ProposalPage: React.FC<ProposalPageProps> = ({ proposalType }) => {
   const { contracts } = useContext(ContractsContext);
   const { account } = useWeb3React<Web3Provider>();
   const router = useRouter();
@@ -42,9 +47,8 @@ const ProposalPage: React.FC = () => {
         contracts.beneficiaryGovernance,
         IpfsClient,
       )
-        .getProposal(Number(proposalId))
+        .getProposal(Number(proposalId), proposalType)
         .then((res) => {
-          console.log(res);
           setProposal(res);
         });
     }

--- a/packages/app/components/Proposals/ProposalPage.tsx
+++ b/packages/app/components/Proposals/ProposalPage.tsx
@@ -50,6 +50,9 @@ const ProposalPage: React.FC<ProposalPageProps> = ({ proposalType }) => {
         .getProposal(Number(proposalId), proposalType)
         .then((res) => {
           setProposal(res);
+        })
+        .catch((err) => {
+          console.log(err);
         });
     }
   }, [contracts, account, proposalId]);

--- a/packages/app/pages/proposals/nominations/[id].tsx
+++ b/packages/app/pages/proposals/nominations/[id].tsx
@@ -1,5 +1,6 @@
+import { ProposalType } from '@popcorn/contracts/adapters';
 import ProposalPage from 'components/Proposals/ProposalPage';
 
 export default function SingleTakedownPage(): JSX.Element {
-  return <ProposalPage />;
+  return <ProposalPage proposalType={ProposalType.Nomination} />;
 }

--- a/packages/app/pages/proposals/takedowns/[id].tsx
+++ b/packages/app/pages/proposals/takedowns/[id].tsx
@@ -1,5 +1,6 @@
+import { ProposalType } from '@popcorn/contracts/adapters';
 import ProposalPage from 'components/Proposals/ProposalPage';
 
 export default function SingleTakedownPage(): JSX.Element {
-  return <ProposalPage />;
+  return <ProposalPage proposalType={ProposalType.Takedown} />;
 }

--- a/packages/contracts/adapters/BeneficiaryGovernance/BeneficiaryGovernanceAdapter.ts
+++ b/packages/contracts/adapters/BeneficiaryGovernance/BeneficiaryGovernanceAdapter.ts
@@ -68,7 +68,9 @@ export class BeneficiaryGovernanceAdapter {
   ): Promise<Proposal> {
     const proposal = await this.contract.proposals(id);
     if (proposal.proposalType !== proposalType)
-      throw ` Error: A ${ProposalType[proposalType]} proposal at index ${id} does not exist`;
+      throw new Error(
+        `Error: A ${ProposalType[proposalType]} proposal at index ${id} does not exist`
+      );
     return {
       application: await this.IpfsClient.get(proposal.applicationCid),
       id: id.toString(),

--- a/packages/contracts/adapters/BeneficiaryGovernance/BeneficiaryGovernanceAdapter.ts
+++ b/packages/contracts/adapters/BeneficiaryGovernance/BeneficiaryGovernanceAdapter.ts
@@ -66,9 +66,9 @@ export class BeneficiaryGovernanceAdapter {
     id: number,
     proposalType: ProposalType
   ): Promise<Proposal> {
-    const proposalTypeName =
-      proposalType === ProposalType.Nomination ? "nominations" : "takedowns";
-    const proposal = await this.contract[proposalTypeName](id);
+    const proposal = await this.contract.proposals(id);
+    if (proposal.proposalType !== proposalType)
+      throw ` Error: A ${ProposalType[proposalType]} proposal at index ${id} does not exist`;
     return {
       application: await this.IpfsClient.get(proposal.applicationCid),
       id: id.toString(),

--- a/packages/contracts/adapters/BeneficiaryGovernance/BeneficiaryGovernanceAdapter.ts
+++ b/packages/contracts/adapters/BeneficiaryGovernance/BeneficiaryGovernanceAdapter.ts
@@ -62,8 +62,13 @@ export interface Proposal {
 export class BeneficiaryGovernanceAdapter {
   constructor(private contract: Contract, private IpfsClient: IIpfsClient) {}
 
-  public async getProposal(id: number): Promise<Proposal> {
-    const proposal = await this.contract.proposals(id);
+  public async getProposal(
+    id: number,
+    proposalType: ProposalType
+  ): Promise<Proposal> {
+    const proposalTypeName =
+      proposalType === ProposalType.Nomination ? "nominations" : "takedowns";
+    const proposal = await this.contract[proposalTypeName](id);
     return {
       application: await this.IpfsClient.get(proposal.applicationCid),
       id: id.toString(),
@@ -88,7 +93,6 @@ export class BeneficiaryGovernanceAdapter {
     const proposalCount = await this.contract.getNumberOfProposals(
       proposalType
     );
-
     const proposalTypeName =
       proposalType === ProposalType.Nomination ? "nominations" : "takedowns";
 
@@ -97,10 +101,9 @@ export class BeneficiaryGovernanceAdapter {
         return this.contract[proposalTypeName](i);
       })
     );
-
     return Promise.all(
       proposalIds.map(async (id) => {
-        return this.getProposal(Number(id));
+        return this.getProposal(Number(id), proposalType);
       })
     );
   }


### PR DESCRIPTION
Closes #302 

- `getProposal` in `BeneficiaryGovernanceAdapter` throws an error if a user navigates to a nomination proposal page providing an id of a takedown proposal and vice versa
- The error is displayed in a toast component