### PR TITLE
Feature/fix stat cards

### DIFF
--- a/packages/emissions-dashboard/next.config.js
+++ b/packages/emissions-dashboard/next.config.js
@@ -7,8 +7,11 @@ const workspace = join(__dirname, '..');
 module.exports = {
   target: 'serverless',
   env: {
+    CHAIN_ID: process.env.CHAIN_ID,
     ETHERSCAN_API_KEY: process.env.ETHERSCAN_API_KEY,
     PATCH_API_KEY: process.env.PATCH_API_KEY,
+    RPC_URL: process.env.RPC_URL,
+    PRIVATE_KEY: process.env.PRIVATE_KEY,
   },
   poweredByHeader: false,
   webpack: (config, options) => {

--- a/packages/emissions-dashboard/pages/index.tsx
+++ b/packages/emissions-dashboard/pages/index.tsx
@@ -14,6 +14,7 @@ import { useRouter } from 'next/router';
 import fetch from 'node-fetch';
 import React, { useEffect, useState } from 'react';
 import web3 from 'web3';
+import { connectors } from '../context/Web3/connectors';
 
 const DEFAULT_CONTRACTS = [
   { name: 'POP', address: '0xd0cd466b34a24fcb2f87676278af2005ca8a78c4' },
@@ -41,7 +42,6 @@ const IndexPage = (): JSX.Element => {
   const [errorMessage, setErrorMessage] = useState<string>('');
   const context = useWeb3React<Web3Provider>();
   const { library, activate, active } = context;
-
   const [contracts, setContracts] = useState<Contract[]>(DEFAULT_CONTRACTS);
   const [previousPeriodStartDate, setPreviousPeriodStartDate] = useState<Date>(
     new Date(DateTime.now().minus({ months: 2 }).toISO()),
@@ -68,6 +68,12 @@ const IndexPage = (): JSX.Element => {
       router.replace(window.location.pathname);
     }
   }, [router.pathname]);
+
+  useEffect(() => {
+    if (!active) {
+      activate(connectors.Network);
+    }
+  }, [active]);
 
   const getTransactions = async () => {
     setReadyState('loading');

--- a/packages/emissions-dashboard/utils/index.ts
+++ b/packages/emissions-dashboard/utils/index.ts
@@ -97,17 +97,23 @@ export const getStatCardData = (
   const totalEmissionsPreviousPeriod = Math.round(
     transactionsPreviousPeriod.reduce((acc, cu) => acc + cu.emissions, 0),
   );
-  const emissionsChangePercentChange = percentChange(
-    totalEmissionsPreviousPeriod,
-    totalEmissionsCurrentPeriod,
-  );
+  const emissionsChangePercentChange =
+    totalEmissionsPreviousPeriod === 0
+      ? `N/A`
+      : `${percentChange(
+          totalEmissionsPreviousPeriod,
+          totalEmissionsCurrentPeriod,
+        )}%`;
 
   const totalTransactionVolCurrentPeriod = transactionsCurrentPeriod.length;
   const totalTransactionVolPreviousPeriod = transactionsPreviousPeriod.length;
-  const transactionVolPercentChange = percentChange(
-    totalTransactionVolPreviousPeriod,
-    totalTransactionVolCurrentPeriod,
-  );
+  const transactionVolPercentChange =
+    totalTransactionVolPreviousPeriod === 0
+      ? `N/A`
+      : `${percentChange(
+          totalTransactionVolPreviousPeriod,
+          totalTransactionVolCurrentPeriod,
+        )}%`;
 
   if (!isTotalStats) {
     return [
@@ -116,16 +122,22 @@ export const getStatCardData = (
         name: 'CO2 Emissions (µg)',
         stat: totalEmissionsCurrentPeriod,
         icon: CloudIcon,
-        change: `${Math.round(emissionsChangePercentChange)}%`,
-        changeType: emissionsChangePercentChange > 0 ? 'increase' : 'decrease',
+        change: emissionsChangePercentChange,
+        changeType:
+          totalEmissionsCurrentPeriod > totalEmissionsPreviousPeriod
+            ? 'increase'
+            : 'decrease',
       },
       {
         id: 2,
         name: 'Transactions',
         stat: totalTransactionVolCurrentPeriod,
         icon: Globe,
-        change: `${transactionVolPercentChange}%`,
-        changeType: transactionVolPercentChange > 0 ? 'increase' : 'decrease',
+        change: transactionVolPercentChange,
+        changeType:
+          totalTransactionVolCurrentPeriod > totalTransactionVolPreviousPeriod
+            ? 'increase'
+            : 'decrease',
       },
     ];
   }
@@ -150,34 +162,46 @@ export const getStatCardData = (
             (GWEI_TO_ETH * transactionsPreviousPeriod.length),
         );
 
-  const gasPricePercentChange = percentChange(
-    averageGasPricePreviousPeriod,
-    averageGasPriceCurrentPeriod,
-  );
+  const gasPricePercentChange =
+    averageGasPricePreviousPeriod === 0
+      ? `N/A`
+      : `${percentChange(
+          averageGasPricePreviousPeriod,
+          averageGasPriceCurrentPeriod,
+        )}%`;
   return [
     {
       id: 1,
       name: 'CO2 Emissions (µg)',
       stat: totalEmissionsCurrentPeriod,
       icon: CloudIcon,
-      change: `${Math.round(emissionsChangePercentChange)}%`,
-      changeType: emissionsChangePercentChange > 0 ? 'increase' : 'decrease',
+      change: emissionsChangePercentChange,
+      changeType:
+        totalEmissionsCurrentPeriod > totalEmissionsPreviousPeriod
+          ? 'increase'
+          : 'decrease',
     },
     {
       id: 2,
       name: 'Transactions',
       stat: totalTransactionVolCurrentPeriod,
       icon: Globe,
-      change: `${transactionVolPercentChange}%`,
-      changeType: transactionVolPercentChange > 0 ? 'increase' : 'decrease',
+      change: transactionVolPercentChange,
+      changeType:
+        totalTransactionVolCurrentPeriod > totalTransactionVolPreviousPeriod
+          ? 'increase'
+          : 'decrease',
     },
     {
       id: 3,
       name: 'Average Gas Price',
       stat: averageGasPriceCurrentPeriod,
       icon: Wind,
-      change: `${gasPricePercentChange}%`,
-      changeType: gasPricePercentChange > 0 ? 'increase' : 'decrease',
+      change: gasPricePercentChange,
+      changeType:
+        averageGasPriceCurrentPeriod > averageGasPricePreviousPeriod
+          ? 'increase'
+          : 'decrease',
     },
   ];
 };

--- a/packages/ui/src/components/popcorn/emissions-dashboard/ContractContainer/index.tsx
+++ b/packages/ui/src/components/popcorn/emissions-dashboard/ContractContainer/index.tsx
@@ -46,6 +46,7 @@ export const ContractContainer: React.FC<ContractContainerProps> = ({
             transactionsPreviousPeriod,
             false,
           )}
+          readyState={readyState}
         />
       </div>
       <div className="max-w-7xl">

--- a/packages/ui/src/components/popcorn/emissions-dashboard/Spinner/index.tsx
+++ b/packages/ui/src/components/popcorn/emissions-dashboard/Spinner/index.tsx
@@ -1,7 +1,12 @@
 import * as SVGLoaders from 'svg-loaders-react';
 
-const Spinner = () => {
-  return <SVGLoaders.Oval stroke="#666666" className="mx-auto h-10 w-10" />;
+const Spinner = ({ size = 10 }) => {
+  return (
+    <SVGLoaders.Oval
+      stroke="#666666"
+      className={`mx-auto h-${size} w-${size}`}
+    />
+  );
 };
 
 export default Spinner;

--- a/packages/ui/src/components/popcorn/emissions-dashboard/StatsCards/index.tsx
+++ b/packages/ui/src/components/popcorn/emissions-dashboard/StatsCards/index.tsx
@@ -27,6 +27,16 @@ const loadingCard = (item: StatCardData) => {
   );
 };
 
+const errorCard = () => {
+  return (
+    <div className="relative h-24 w-64 flex items-stretch justify-center bg-white px-4  shadow rounded-lg overflow-hidden">
+      <p className="text-sm self-center text-gray-500 ">
+        Error loading transactions
+      </p>
+    </div>
+  );
+};
+
 export const StatsCards: React.FC<StatsCardProps> = ({
   stats,
   iconCol = 'bg-indigo-500',
@@ -36,6 +46,7 @@ export const StatsCards: React.FC<StatsCardProps> = ({
     <div className="w-screen grid justify-items-stretch">
       <dl className="justify-self-start mt-5 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
         {readyState === 'loading' && stats.map((item) => loadingCard(item))}
+
         {readyState === 'done' &&
           stats.map((item) => (
             <div
@@ -85,6 +96,7 @@ export const StatsCards: React.FC<StatsCardProps> = ({
               </dd>
             </div>
           ))}
+        {readyState === 'error' && errorCard()}
       </dl>
     </div>
   );

--- a/packages/ui/src/components/popcorn/emissions-dashboard/StatsCards/index.tsx
+++ b/packages/ui/src/components/popcorn/emissions-dashboard/StatsCards/index.tsx
@@ -1,6 +1,11 @@
 import { ArrowSmDownIcon, ArrowSmUpIcon } from '@heroicons/react/solid';
 import React from 'react';
-import { StatCardData } from '../../../../interfaces/emissions-dashboard';
+import {
+  ChartReadyState,
+  StatCardData,
+} from '../../../../interfaces/emissions-dashboard';
+import Spinner from '../Spinner';
+
 function classNames(...classes) {
   return classes.filter(Boolean).join(' ');
 }
@@ -8,60 +13,78 @@ function classNames(...classes) {
 interface StatsCardProps {
   stats: StatCardData[];
   iconCol?: string;
+  readyState: ChartReadyState;
 }
+
+const loadingCard = (item: StatCardData) => {
+  return (
+    <div
+      key={item.name}
+      className="relative h-24 w-64 bg-white px-4 sm:py-7 sm:px-6 shadow rounded-lg overflow-hidden"
+    >
+      <Spinner />
+    </div>
+  );
+};
 
 export const StatsCards: React.FC<StatsCardProps> = ({
   stats,
   iconCol = 'bg-indigo-500',
+  readyState,
 }): JSX.Element => {
   return (
     <div className="w-screen grid justify-items-stretch">
       <dl className="justify-self-start mt-5 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
-        {stats.map((item) => (
-          <div
-            key={item.name}
-            className="relative h-24 w-64 bg-white pt-5 px-4 pb-12 sm:pt-6 sm:px-6 shadow rounded-lg overflow-hidden"
-          >
-            <dt>
-              <div className={`absolute ${iconCol} rounded-md p-3`}>
-                <item.icon className="h-6 w-6 text-white" aria-hidden="true" />
-              </div>
-              <p className="ml-16 text-sm font-medium text-gray-500 truncate">
-                {item.name}
-              </p>
-            </dt>
-            <dd className="ml-16 pb-6 flex items-baseline sm:pb-7">
-              <p className="text-2xl font-semibold text-gray-900">
-                {item.stat.toLocaleString()}
-              </p>
-              <p
-                className={classNames(
-                  item.changeType === 'increase'
-                    ? 'text-green-600'
-                    : 'text-red-600',
-                  'ml-2 flex items-baseline text-sm font-semibold',
-                )}
-              >
-                {item.changeType === 'increase' ? (
-                  <ArrowSmUpIcon
-                    className="self-center flex-shrink-0 h-5 w-5 text-green-500"
+        {readyState === 'loading' && stats.map((item) => loadingCard(item))}
+        {readyState === 'done' &&
+          stats.map((item) => (
+            <div
+              key={item.name}
+              className="relative h-24 w-64 bg-white pt-5 px-4 pb-12 sm:pt-6 sm:px-6 shadow rounded-lg overflow-hidden"
+            >
+              <dt>
+                <div className={`absolute ${iconCol} rounded-md p-3`}>
+                  <item.icon
+                    className="h-6 w-6 text-white"
                     aria-hidden="true"
                   />
-                ) : (
-                  <ArrowSmDownIcon
-                    className="self-center flex-shrink-0 h-5 w-5 text-red-500"
-                    aria-hidden="true"
-                  />
-                )}
-                <span className="sr-only">
-                  {item.changeType === 'increase' ? 'Increased' : 'Decreased'}{' '}
-                  by
-                </span>
-                {item.change}
-              </p>
-            </dd>
-          </div>
-        ))}
+                </div>
+                <p className="ml-16 text-sm font-medium text-gray-500 truncate">
+                  {item.name}
+                </p>
+              </dt>
+              <dd className="ml-16 pb-6 flex items-baseline sm:pb-7">
+                <p className="text-2xl font-semibold text-gray-900">
+                  {item.stat.toLocaleString()}
+                </p>
+                <p
+                  className={classNames(
+                    item.changeType === 'increase'
+                      ? 'text-green-600'
+                      : 'text-red-600',
+                    'ml-2 flex items-baseline text-sm font-semibold',
+                  )}
+                >
+                  {item.changeType === 'increase' ? (
+                    <ArrowSmUpIcon
+                      className="self-center flex-shrink-0 h-5 w-5 text-green-500"
+                      aria-hidden="true"
+                    />
+                  ) : (
+                    <ArrowSmDownIcon
+                      className="self-center flex-shrink-0 h-5 w-5 text-red-500"
+                      aria-hidden="true"
+                    />
+                  )}
+                  <span className="sr-only">
+                    {item.changeType === 'increase' ? 'Increased' : 'Decreased'}{' '}
+                    by
+                  </span>
+                  {item.change}
+                </p>
+              </dd>
+            </div>
+          ))}
       </dl>
     </div>
   );

--- a/packages/ui/src/components/popcorn/emissions-dashboard/StatsCards/index.tsx
+++ b/packages/ui/src/components/popcorn/emissions-dashboard/StatsCards/index.tsx
@@ -7,10 +7,12 @@ function classNames(...classes) {
 
 interface StatsCardProps {
   stats: StatCardData[];
+  iconCol?: string;
 }
 
 export const StatsCards: React.FC<StatsCardProps> = ({
   stats,
+  iconCol = 'bg-indigo-500',
 }): JSX.Element => {
   return (
     <div className="w-screen grid justify-items-stretch">
@@ -21,7 +23,7 @@ export const StatsCards: React.FC<StatsCardProps> = ({
             className="relative h-24 w-64 bg-white pt-5 px-4 pb-12 sm:pt-6 sm:px-6 shadow rounded-lg overflow-hidden"
           >
             <dt>
-              <div className="absolute bg-indigo-500 rounded-md p-3">
+              <div className={`absolute ${iconCol} rounded-md p-3`}>
                 <item.icon className="h-6 w-6 text-white" aria-hidden="true" />
               </div>
               <p className="ml-16 text-sm font-medium text-gray-500 truncate">

--- a/packages/ui/src/components/popcorn/emissions-dashboard/TotalStats/index.tsx
+++ b/packages/ui/src/components/popcorn/emissions-dashboard/TotalStats/index.tsx
@@ -49,6 +49,7 @@ export const TotalStats: React.FC<TotalStatsProps> = ({
             transactionsPreviousPeriod,
             true,
           )}
+          readyState={readyState}
         />
       </div>
       <div className="max-w-7xl">


### PR DESCRIPTION
Closes #527

- Displays Spinner during 'loading' ReadyState:
![image](https://user-images.githubusercontent.com/3315297/135447988-1ae6c938-171c-4e5b-b0d4-6ab48b055024.png)
- Displays Error error during 'error' ReadyState:
![image](https://user-images.githubusercontent.com/3315297/135448046-b1501b82-8020-42d3-ae9e-86d193f13fd9.png)
- Increases from 0 are displayed as 'N/A'.
- Icon colours can be passed via component props.